### PR TITLE
Python3 syntax error fixed.

### DIFF
--- a/medpy/core/logger.py
+++ b/medpy/core/logger.py
@@ -91,7 +91,7 @@ class Logger (NativeLogger):
     def __init__(self, name = 'MedPyLogger', level = 0) :
         # To guarantee that no one created more than one instance of Logger:
         if not Logger._instance == None :
-            raise RuntimeError, 'Only one instance of Logger is allowed!'
+            raise RuntimeError('Only one instance of Logger is allowed!')
         
         # initialize parent
         NativeLogger.__init__(self, name, level)


### PR DESCRIPTION
`raise RuntimeError 'Only one instance of Logger is allowed!'`
needs to be
`raise RuntimeError('Only one instance of Logger is allowed!')`
to work as valid python 3.4 syntax.
