### PR TITLE
Fix python 3 incompatibilities + add tests

### DIFF
--- a/medpy/filter/smoothing.py
+++ b/medpy/filter/smoothing.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -34,10 +34,10 @@ from .utilities import xminus1d
 def gauss_xminus1d(img, sigma, dim=2):
     r"""
     Applies a X-1D gauss to a copy of a XD image, slicing it along dim.
-    
+
     Essentially uses `scipy.ndimage.filters.gaussian_filter`, but
     applies it to a dimension less than the image has.
-    
+
     Parameters
     ----------
     img : array_like
@@ -46,11 +46,11 @@ def gauss_xminus1d(img, sigma, dim=2):
         The sigma i.e. gaussian kernel size in pixel
     dim : integer
         The dimension along which to apply the filter.
-        
+
     Returns
     -------
     gauss_xminus1d : ndarray
-        The input image ``img`` smoothed by a gaussian kernel along dimension ``dim``. 
+        The input image ``img`` smoothed by a gaussian kernel along dimension ``dim``.
     """
     img = numpy.array(img, copy=False)
     return xminus1d(img, gaussian_filter, dim, sigma=sigma)
@@ -85,7 +85,7 @@ def anisotropic_diffusion(img, niter=1, kappa=50, gamma=0.1, voxelspacing=None, 
     -------
     anisotropic_diffusion : ndarray
         Diffused image.
-        
+
     Notes
     -----
     Original MATLAB code by Peter Kovesi,
@@ -98,22 +98,22 @@ def anisotropic_diffusion(img, niter=1, kappa=50, gamma=0.1, voxelspacing=None, 
     Department of Pharmacology,
     University of Oxford,
     <alistair.muldal@pharm.ox.ac.uk>
-    
+
     Adapted to arbitrary dimensionality and added to the MedPy library Oskar Maier,
     Institute for Medical Informatics,
     Universitaet Luebeck,
     <oskar.maier@googlemail.com>
-    
+
     June 2000  original version. -
-    March 2002 corrected diffusion eqn No 2. - 
+    March 2002 corrected diffusion eqn No 2. -
     July 2012 translated to Python -
-    August 2013 incorporated into MedPy, arbitrary dimensionality -    
+    August 2013 incorporated into MedPy, arbitrary dimensionality -
 
     References
     ----------
-    .. [1] P. Perona and J. Malik. 
+    .. [1] P. Perona and J. Malik.
        Scale-space and edge detection using ansotropic diffusion.
-       IEEE Transactions on Pattern Analysis and Machine Intelligence, 
+       IEEE Transactions on Pattern Analysis and Machine Intelligence,
        12(7):629-639, July 1990.
     """
     # define conduction gradients functions
@@ -126,28 +126,28 @@ def anisotropic_diffusion(img, niter=1, kappa=50, gamma=0.1, voxelspacing=None, 
 
     # initialize output array
     out = numpy.array(img, dtype=numpy.float32, copy=True)
-    
+
     # set default voxel spacong if not suppliec
     if None == voxelspacing:
         voxelspacing = tuple([1.] * img.ndim)
 
     # initialize some internal variables
-    deltas = [numpy.zeros_like(out) for _ in xrange(out.ndim)]
+    deltas = [numpy.zeros_like(out) for _ in range(out.ndim)]
 
-    for _ in xrange(niter):
+    for _ in range(niter):
 
         # calculate the diffs
-        for i in xrange(out.ndim):
-            slicer = [slice(None, -1) if j == i else slice(None) for j in xrange(out.ndim)]
+        for i in range(out.ndim):
+            slicer = [slice(None, -1) if j == i else slice(None) for j in range(out.ndim)]
             deltas[i][slicer] = numpy.diff(out, axis=i)
-        
+
         # update matrices
         matrices = [condgradient(delta, spacing) * delta for delta, spacing in zip(deltas, voxelspacing)]
 
         # subtract a copy that has been shifted ('Up/North/West' in 3D case) by one
         # pixel. Don't as questions. just do it. trust me.
-        for i in xrange(out.ndim):
-            slicer = [slice(1, None) if j == i else slice(None) for j in xrange(out.ndim)]
+        for i in range(out.ndim):
+            slicer = [slice(1, None) if j == i else slice(None) for j in range(out.ndim)]
             matrices[i][slicer] = numpy.diff(matrices[i], axis=i)
 
         # update the image

--- a/tests/filter_/anisotropic_diffusion.py
+++ b/tests/filter_/anisotropic_diffusion.py
@@ -1,0 +1,34 @@
+import unittest
+import scipy
+import numpy as np
+
+from medpy.filter import anisotropic_diffusion
+
+# Purpose of these tests is to ensure the filter code does not crash
+# Depending on Python versions
+
+def test_anisotropic_diffusion_powerof2_single_channel():
+    arr = np.random.uniform(size=(64,64))
+    filtered = anisotropic_diffusion(arr)
+    assert filtered.shape == arr.shape
+
+def test_anisotropic_diffusion_powerof2_three_channels():
+    # Purpose of this test is to ensure the filter code does not crash
+    # Depending on Python versions
+    arr = np.random.uniform(size=(64,64,3))
+    filtered = anisotropic_diffusion(arr)
+    assert filtered.shape == arr.shape
+
+def test_anisotropic_diffusion_single_channel():
+    # Purpose of this test is to ensure the filter code does not crash
+    # Depending on Python versions
+    arr = np.random.uniform(size=(60,31))
+    filtered = anisotropic_diffusion(arr)
+    assert filtered.shape == arr.shape
+
+def test_anisotropic_diffusion_three_channels():
+    # Purpose of this test is to ensure the filter code does not crash
+    # Depending on Python versions
+    arr = np.random.uniform(size=(60,31,3))
+    filtered = anisotropic_diffusion(arr)
+    assert filtered.shape == arr.shape


### PR DESCRIPTION
Replaced `xrange` in favor of range, to be compatible with python 3. 

I haven't benchmarked it but it should not impact performances that much, given that `xrange` was always called with small values (`arr.ndim`).