### PR TITLE
Added 95th percentile of Hausdorf Distance

### DIFF
--- a/medpy/metric/__init__.py
+++ b/medpy/metric/__init__.py
@@ -116,7 +116,7 @@ Histogram metrics (:mod:`medpy.metric.histogram`)
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # import all functions/methods/classes into the module
-from .binary import asd, assd, dc, hd, jc, positive_predictive_value, precision, ravd, recall, sensitivity, specificity, true_negative_rate, true_positive_rate
+from .binary import asd, assd, dc, hd, jc, positive_predictive_value, precision, ravd, recall, sensitivity, specificity, true_negative_rate, true_positive_rate, hd95
 from .binary import obj_asd, obj_assd, obj_fpr, obj_tpr
 from .binary import volume_change_correlation, volume_correlation
 from .histogram import chebyshev, chebyshev_neg, chi_square, correlate, correlate_1, cosine,\

--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -350,6 +350,56 @@ def hd(result, reference, voxelspacing=None, connectivity=1):
     hd = max(hd1, hd2)
     return hd
 
+
+def hd95(result, reference, voxelspacing=None, connectivity=1):
+    """
+    95th percentile of the Hausdorff Distance.
+
+    Computes the 95th percentile of the (symmetric) Hausdorff Distance (HD) between the binary objects in two
+    images. Compared to the Hausdorff Distance, this metric is slightly more stable to small outliers and is 
+    commonly used in Biomedical Segmentation challenges.
+
+    Parameters
+    ----------
+    result : array_like
+        Input data containing objects. Can be any type but will be converted
+        into binary: background where 0, object everywhere else.
+    reference : array_like
+        Input data containing objects. Can be any type but will be converted
+        into binary: background where 0, object everywhere else.
+    voxelspacing : float or sequence of floats, optional
+        The voxelspacing in a distance unit i.e. spacing of elements
+        along each dimension. If a sequence, must be of length equal to
+        the input rank; if a single number, this is used for all axes. If
+        not specified, a grid spacing of unity is implied.
+    connectivity : int
+        The neighbourhood/connectivity considered when determining the surface
+        of the binary objects. This value is passed to
+        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        Note that the connectivity influences the result in the case of the Hausdorff distance.
+
+    Returns
+    -------
+    hd : float
+        The symmetric Hausdorff Distance between the object(s) in ```result``` and the
+        object(s) in ```reference```. The distance unit is the same as for the spacing of 
+        elements along each dimension, which is usually given in mm.
+
+    See also
+    --------
+    :func:`hd`
+
+    Notes
+    -----
+    This is a real metric. The binary images can therefore be supplied in any order.
+    """
+    import numpy as np
+    hd1 = __surface_distances(result, reference, voxelspacing, connectivity)
+    hd2 = __surface_distances(reference, result, voxelspacing, connectivity)
+    hd95 = np.percentile(np.hstack((hd1, hd2)), 95)
+    return hd95
+
+
 def assd(result, reference, voxelspacing=None, connectivity=1):
     """
     Average symmetric surface distance.

--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -395,7 +395,7 @@ def hd95(result, reference, voxelspacing=None, connectivity=1):
     """
     hd1 = __surface_distances(result, reference, voxelspacing, connectivity)
     hd2 = __surface_distances(reference, result, voxelspacing, connectivity)
-    hd95 = numpy.percentile(np.hstack((hd1, hd2)), 95)
+    hd95 = numpy.percentile(numpy.hstack((hd1, hd2)), 95)
     return hd95
 
 

--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -356,7 +356,7 @@ def hd95(result, reference, voxelspacing=None, connectivity=1):
     95th percentile of the Hausdorff Distance.
 
     Computes the 95th percentile of the (symmetric) Hausdorff Distance (HD) between the binary objects in two
-    images. Compared to the Hausdorff Distance, this metric is slightly more stable to small outliers and is 
+    images. Compared to the Hausdorff Distance, this metric is slightly more stable to small outliers and is
     commonly used in Biomedical Segmentation challenges.
 
     Parameters
@@ -393,10 +393,9 @@ def hd95(result, reference, voxelspacing=None, connectivity=1):
     -----
     This is a real metric. The binary images can therefore be supplied in any order.
     """
-    import numpy as np
     hd1 = __surface_distances(result, reference, voxelspacing, connectivity)
     hd2 = __surface_distances(reference, result, voxelspacing, connectivity)
-    hd95 = np.percentile(np.hstack((hd1, hd2)), 95)
+    hd95 = numpy.percentile(np.hstack((hd1, hd2)), 95)
     return hd95
 
 


### PR DESCRIPTION
This is a common metric used in biomedical segmentation challenges. It is a bit more stable to outliers than the HD but still gives a very good estimate of the segmentation quality. It is used in the BraTS challenge for example and I think it would be good to give participants the opportunity to compute this metric themselves during model development. Disclaimer: I don't know the exact implementation the BraTS organizer are using, so there may be differences.
