### PR TITLE
Fix numpy slicing

### DIFF
--- a/medpy/filter/smoothing.py
+++ b/medpy/filter/smoothing.py
@@ -151,7 +151,7 @@ def anisotropic_diffusion(img, niter=1, kappa=50, gamma=0.1, voxelspacing=None, 
 
         # calculate the diffs
         for i in range(out.ndim):
-            slicer = [slice(None, -1) if j == i else slice(None) for j in range(out.ndim)]
+            slicer = tuple([slice(None, -1) if j == i else slice(None) for j in range(out.ndim)])
             deltas[i][slicer] = numpy.diff(out, axis=i)
 
         # update matrices
@@ -160,7 +160,7 @@ def anisotropic_diffusion(img, niter=1, kappa=50, gamma=0.1, voxelspacing=None, 
         # subtract a copy that has been shifted ('Up/North/West' in 3D case) by one
         # pixel. Don't as questions. just do it. trust me.
         for i in range(out.ndim):
-            slicer = [slice(1, None) if j == i else slice(None) for j in range(out.ndim)]
+            slicer = tuple([slice(1, None) if j == i else slice(None) for j in range(out.ndim)])
             matrices[i][slicer] = numpy.diff(matrices[i], axis=i)
 
         # update the image


### PR DESCRIPTION
In numpy 1.23.1 (or sooner, I didn't bisect it) using lists to slice is no longer allowed. It gives the error message: 

`IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices`

This PR fixes it by casting to a tuple being using as a slice. 