### PR TITLE
Fixed dice coef. return value on emtpy sets

### DIFF
--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -76,7 +76,7 @@ def dc(result, reference):
     try:
         dc = 2. * intersection / float(size_i1 + size_i2)
     except ZeroDivisionError:
-        dc = 0.0
+        dc = 1.0
     
     return dc
 

--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -111,7 +111,10 @@ def jc(result, reference):
     intersection = numpy.count_nonzero(result & reference)
     union = numpy.count_nonzero(result | reference)
     
-    jc = float(intersection) / float(union)
+    try:
+        jc = float(intersection) / float(union)
+    except ZeroDivisionError:
+        jc = 1.0
     
     return jc
 


### PR DESCRIPTION
While not clearly defined, the convention seems to be that an empty result and reference set should cause the dice coefficient to return `1` (i.e. a perfect result) rather than `0`. Adapted accordingly.

Fixes #106 