### PR TITLE
Stop using deprecated scipy namespaces

### DIFF
--- a/bin/medpy_apparent_diffusion_coefficient.py
+++ b/bin/medpy_apparent_diffusion_coefficient.py
@@ -25,7 +25,7 @@ import logging
 
 # third-party modules
 import numpy
-from scipy.ndimage.morphology import binary_fill_holes, binary_dilation,\
+from scipy.ndimage import binary_fill_holes, binary_dilation,\
     binary_erosion
 
 # path changes

--- a/bin/medpy_binary_resampling.py
+++ b/bin/medpy_binary_resampling.py
@@ -26,9 +26,9 @@ import argparse
 
 # third-party modules
 import numpy
-from scipy.ndimage.interpolation import zoom
-from scipy.ndimage.morphology import distance_transform_edt, binary_erosion
-from scipy.ndimage.measurements import label
+from scipy.ndimage import zoom
+from scipy.ndimage import distance_transform_edt, binary_erosion
+from scipy.ndimage import label
 
 # own modules
 from medpy.core import Logger

--- a/bin/medpy_extract_contour.py
+++ b/bin/medpy_extract_contour.py
@@ -26,7 +26,7 @@ import math
 
 # third-party modules
 import numpy
-from scipy.ndimage.morphology import binary_erosion, binary_dilation,\
+from scipy.ndimage import binary_erosion, binary_dilation,\
     generate_binary_structure
 
 # path changes

--- a/bin/medpy_fit_into_shape.py
+++ b/bin/medpy_fit_into_shape.py
@@ -26,9 +26,9 @@ import argparse
 
 # third-party modules
 import numpy
-from scipy.ndimage.interpolation import zoom
-from scipy.ndimage.morphology import distance_transform_edt, binary_erosion
-from scipy.ndimage.measurements import label
+from scipy.ndimage import zoom
+from scipy.ndimage import distance_transform_edt, binary_erosion
+from scipy.ndimage import label
 
 # own modules
 from medpy.core import Logger

--- a/bin/medpy_gradient.py
+++ b/bin/medpy_gradient.py
@@ -25,7 +25,7 @@ import logging
 
 # third-party modules
 import scipy
-from scipy.ndimage.filters import generic_gradient_magnitude, prewitt
+from scipy.ndimage import generic_gradient_magnitude, prewitt
 
 # path changes
 

--- a/bin/medpy_morphology.py
+++ b/bin/medpy_morphology.py
@@ -24,7 +24,7 @@ import argparse
 import logging
 
 # third-party modules
-import scipy.ndimage.morphology
+import scipy.ndimage
 
 # path changes
 
@@ -64,23 +64,23 @@ def main():
         
     # perform opening resp. closing
     # in 3D case: size 1 = 6-connectedness, 2 = 12-connectedness, 3 = 18-connectedness, etc.
-    footprint = scipy.ndimage.morphology.generate_binary_structure(image_smoothed_data.ndim, args.size)
+    footprint = scipy.ndimage.generate_binary_structure(image_smoothed_data.ndim, args.size)
     if 'erosion' == args.type:
         logger.info('Applying erosion...')
-        image_smoothed_data = scipy.ndimage.morphology.binary_erosion(image_smoothed_data, footprint, iterations=args.iterations)
+        image_smoothed_data = scipy.ndimage.binary_erosion(image_smoothed_data, footprint, iterations=args.iterations)
     elif 'dilation' == args.type:
         logger.info('Applying dilation...')
-        image_smoothed_data = scipy.ndimage.morphology.binary_dilation(image_smoothed_data, footprint, iterations=args.iterations)
+        image_smoothed_data = scipy.ndimage.binary_dilation(image_smoothed_data, footprint, iterations=args.iterations)
     elif 'opening' == args.type:
         logger.info('Applying opening...')
-        image_smoothed_data = scipy.ndimage.morphology.binary_opening(image_smoothed_data, footprint, iterations=args.iterations)
+        image_smoothed_data = scipy.ndimage.binary_opening(image_smoothed_data, footprint, iterations=args.iterations)
     else: # closing
         logger.info('Applying closing...')
-        image_smoothed_data = scipy.ndimage.morphology.binary_closing(image_smoothed_data, footprint, iterations=args.iterations)
+        image_smoothed_data = scipy.ndimage.binary_closing(image_smoothed_data, footprint, iterations=args.iterations)
 
     # apply additional hole closing step
     logger.info('Closing holes...')
-    image_smoothed_data = scipy.ndimage.morphology.binary_fill_holes(image_smoothed_data)
+    image_smoothed_data = scipy.ndimage.binary_fill_holes(image_smoothed_data)
 
     # save resulting mas
     save(image_smoothed_data, args.output, image_header, args.force)

--- a/bin/medpy_resample.py
+++ b/bin/medpy_resample.py
@@ -25,7 +25,7 @@ import argparse
 import logging
 
 # third-party modules
-import scipy.ndimage.interpolation
+import scipy.ndimage
 
 # path changes
 
@@ -83,7 +83,7 @@ def main():
     logger.debug('zoom-factors: {}'.format(zoom_factors))
 
     # zoom image
-    img = scipy.ndimage.interpolation.zoom(img, zoom_factors, order=args.order)
+    img = scipy.ndimage.zoom(img, zoom_factors, order=args.order)
     logger.debug('new image shape: {}'.format(img.shape))
 
     # set new voxel spacing

--- a/bin/medpy_watershed.py
+++ b/bin/medpy_watershed.py
@@ -27,7 +27,7 @@ import os
 
 # third-party modules
 import numpy
-from scipy.ndimage.measurements import label
+from scipy.ndimage import label
 from skimage.morphology import watershed
 
 # path changes

--- a/medpy/features/intensity.py
+++ b/medpy/features/intensity.py
@@ -22,10 +22,10 @@
 
 # third-party modules
 import numpy
-from scipy.ndimage.filters import gaussian_filter, median_filter
-from scipy.ndimage.filters import gaussian_gradient_magnitude as scipy_gaussian_gradient_magnitude
+from scipy.ndimage import gaussian_filter, median_filter
+from scipy.ndimage import gaussian_gradient_magnitude as scipy_gaussian_gradient_magnitude
 from scipy.interpolate.interpolate import interp1d
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 from scipy.ndimage._ni_support import _get_output
 
 # own modules

--- a/medpy/features/texture.py
+++ b/medpy/features/texture.py
@@ -22,7 +22,7 @@
 
 # third-party modules
 import numpy
-from scipy.ndimage.filters import uniform_filter, sobel, maximum_filter, minimum_filter, gaussian_filter
+from scipy.ndimage import uniform_filter, sobel, maximum_filter, minimum_filter, gaussian_filter
 from scipy import stats
 from math import factorial
 

--- a/medpy/filter/binary.py
+++ b/medpy/filter/binary.py
@@ -23,7 +23,7 @@ from operator import  lt, le, gt, ge, ne, eq
 
 # third-party modules
 import numpy 
-from scipy.ndimage.measurements import label
+from scipy.ndimage import label
 
 # own modules
 

--- a/medpy/filter/image.py
+++ b/medpy/filter/image.py
@@ -25,9 +25,9 @@ import math
 
 # third-party modules
 import numpy
-from scipy.ndimage.filters import convolve, gaussian_filter, minimum_filter
+from scipy.ndimage import convolve, gaussian_filter, minimum_filter
 from scipy.ndimage._ni_support import _get_output
-from scipy.ndimage.interpolation import zoom
+from scipy.ndimage import zoom
 
 # own modules
 from .utilities import pad, __make_footprint
@@ -273,7 +273,7 @@ def average_filter(input, size=None, footprint=None, output=None, mode="reflect"
 
     See Also
     --------
-    scipy.ndimage.filters.convolve : Convolve an image with a kernel.
+    scipy.ndimage.convolve : Convolve an image with a kernel.
     """
     footprint = __make_footprint(input, size, footprint)
     filter_size = footprint.sum()
@@ -330,7 +330,7 @@ def sum_filter(input, size=None, footprint=None, output=None, mode="reflect", cv
 
     See Also
     --------
-    scipy.ndimage.filters.convolve : Convolve an image with a kernel.
+    scipy.ndimage.convolve : Convolve an image with a kernel.
     """
     footprint = __make_footprint(input, size, footprint)
     slicer = [slice(None, None, -1)] * footprint.ndim 

--- a/medpy/filter/noise.py
+++ b/medpy/filter/noise.py
@@ -23,7 +23,7 @@
 # third-party modules
 import numpy
 from scipy.ndimage import _ni_support
-from scipy.ndimage.filters import convolve1d
+from scipy.ndimage import convolve1d
 
 # own modules
 

--- a/medpy/filter/smoothing.py
+++ b/medpy/filter/smoothing.py
@@ -22,7 +22,7 @@
 
 # third-party modules
 import numpy
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 # path changes
 
@@ -35,7 +35,7 @@ def gauss_xminus1d(img, sigma, dim=2):
     r"""
     Applies a X-1D gauss to a copy of a XD image, slicing it along dim.
 
-    Essentially uses `scipy.ndimage.filters.gaussian_filter`, but
+    Essentially uses `scipy.ndimage.gaussian_filter`, but
     applies it to a dimension less than the image has.
 
     Parameters

--- a/medpy/graphcut/energy_label.py
+++ b/medpy/graphcut/energy_label.py
@@ -86,7 +86,7 @@ def boundary_difference_of_means(graph, label_image, original_image): # label im
     
     # compute the mean intensities of all regions
     # Note: Bug in mean implementation: means over labels is only computed if the indexes are also supplied
-    means = scipy.ndimage.measurements.mean(original_image, labels=label_image, index=labels_unique)
+    means = scipy.ndimage.mean(original_image, labels=label_image, index=labels_unique)
     
     # compute the maximum possible intensity difference
     max_difference = float(abs(min(means) - max(means)))

--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -23,9 +23,9 @@
 # third-party modules
 import numpy
 from scipy.ndimage import _ni_support
-from scipy.ndimage.morphology import distance_transform_edt, binary_erosion,\
+from scipy.ndimage import distance_transform_edt, binary_erosion,\
     generate_binary_structure
-from scipy.ndimage.measurements import label, find_objects
+from scipy.ndimage import label, find_objects
 from scipy.stats import pearsonr
 
 # own modules
@@ -329,7 +329,7 @@ def hd(result, reference, voxelspacing=None, connectivity=1):
     connectivity : int
         The neighbourhood/connectivity considered when determining the surface
         of the binary objects. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         Note that the connectivity influences the result in the case of the Hausdorff distance.
         
     Returns
@@ -378,7 +378,7 @@ def hd95(result, reference, voxelspacing=None, connectivity=1):
     connectivity : int
         The neighbourhood/connectivity considered when determining the surface
         of the binary objects. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         Note that the connectivity influences the result in the case of the Hausdorff distance.
 
     Returns
@@ -425,7 +425,7 @@ def assd(result, reference, voxelspacing=None, connectivity=1):
     connectivity : int
         The neighbourhood/connectivity considered when determining the surface
         of the binary objects. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.         
         
@@ -478,7 +478,7 @@ def asd(result, reference, voxelspacing=None, connectivity=1):
     connectivity : int
         The neighbourhood/connectivity considered when determining the surface
         of the binary objects. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
     
@@ -507,7 +507,7 @@ def asd(result, reference, voxelspacing=None, connectivity=1):
     The `connectivity` determines what pixels/voxels are considered the surface of a
     binary object. Take the following binary image showing a cross
     
-    >>> from scipy.ndimage.morphology import generate_binary_structure
+    >>> from scipy.ndimage import generate_binary_structure
     >>> cross = generate_binary_structure(2, 1)
     array([[0, 1, 0],
            [1, 1, 1],
@@ -747,7 +747,7 @@ def obj_assd(result, reference, voxelspacing=None, connectivity=1):
         The neighbourhood/connectivity considered when determining what accounts
         for a distinct binary object as well as when determining the surface
         of the binary objects. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
         
@@ -802,7 +802,7 @@ def obj_asd(result, reference, voxelspacing=None, connectivity=1):
         The neighbourhood/connectivity considered when determining what accounts
         for a distinct binary object as well as when determining the surface
         of the binary objects. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
         
@@ -934,7 +934,7 @@ def obj_fpr(result, reference, connectivity=1):
     connectivity : int
         The neighbourhood/connectivity considered when determining what accounts
         for a distinct binary object. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
         
@@ -1045,7 +1045,7 @@ def obj_tpr(result, reference, connectivity=1):
     connectivity : int
         The neighbourhood/connectivity considered when determining what accounts
         for a distinct binary object. This value is passed to
-        `scipy.ndimage.morphology.generate_binary_structure` and should usually be :math:`> 1`.
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
         

--- a/tests/filter_/image.py
+++ b/tests/filter_/image.py
@@ -16,7 +16,7 @@ import numpy
 
 # own modules
 from medpy.filter.image import ssd, sls, sum_filter, average_filter
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 # code
 class TestMetrics(unittest.TestCase):


### PR DESCRIPTION
A certain number of scipy.ndimage namespaces are deprecated, this PR ensures future-proofness.