### PR TITLE
Update datatypes for Numpy 1.24

### DIFF
--- a/bin/medpy_binary_resampling.py
+++ b/bin/medpy_binary_resampling.py
@@ -58,7 +58,7 @@ Note that the pixel data type of the input image is treated as binary.
 Copyright (C) 2013 Oskar Maier
 This program comes with ABSOLUTELY NO WARRANTY; This is free software,
 and you are welcome to redistribute it under certain conditions; see
-the LICENSE file or <http://www.gnu.org/licenses/> for details.   
+the LICENSE file or <http://www.gnu.org/licenses/> for details.
 """
 
 # code
@@ -70,31 +70,31 @@ def main():
     logger = Logger.getInstance()
     if args.debug: logger.setLevel(logging.DEBUG)
     elif args.verbose: logger.setLevel(logging.INFO)
-    
+
     # loading input images
     img, hdr = load(args.input)
-    img = img.astype(numpy.bool)
-    
+    img = img.astype(numpy.bool_)
+
     # check spacing values
     if not len(args.spacing) == img.ndim:
         parser.error('The image has {} dimensions, but {} spacing parameters have been supplied.'.format(img.ndim, len(args.spacing)))
-        
+
     # check if output image exists
     if not args.force:
         if os.path.exists(args.output):
-            parser.error('The output image {} already exists.'.format(args.output)) 
-        
+            parser.error('The output image {} already exists.'.format(args.output))
+
     logger.debug('target voxel spacing: {}'.format(args.spacing))
-    
+
     # determine number of required complete slices for up-sampling
     vs = header.get_pixel_spacing(hdr)
     rcss = [int(y // x - 1) for x, y in zip(args.spacing, vs)] # TODO: For option b, remove the - 1; better: no option b, since I am rounding later anyway
-    
+
     # remove negatives and round up to next even number
     rcss = [x if x > 0 else 0 for x in rcss]
     rcss = [x if 0 == x % 2 else x + 1 for x in rcss]
     logger.debug('intermediate slices to add per dimension: {}'.format(rcss))
-    
+
     # for each dimension requiring up-sampling, from the highest down, perform shape based slice interpolation
     logger.info('Adding required slices using shape based interpolation.')
     for dim, rcs in enumerate(rcss):
@@ -102,27 +102,27 @@ def main():
             logger.debug('adding {} intermediate slices to dimension {}'.format(rcs, dim))
             img = shape_based_slice_interpolation(img, dim, rcs)
             logger.debug('resulting new image shape: {}'.format(img.shape))
-            
+
     # compute and set new voxel spacing
     nvs = [x / (y + 1.) for x, y in zip(vs, rcss)]
     header.set_pixel_spacing(hdr, nvs)
     logger.debug('intermediate voxel spacing: {}'.format(nvs))
-    
+
     # interpolate with nearest neighbour
     logger.info('Re-sampling the image with a b-spline order of {}.'.format(args.order))
     img, hdr = resample(img, hdr, args.spacing, args.order, mode='nearest')
-    
+
     # saving the resulting image
     save(img, args.output, hdr, args.force)
-    
+
 def shape_based_slice_interpolation(img, dim, nslices):
     """
     Adds `nslices` slices between all slices of the binary image `img` along dimension
     `dim` respecting the original slice values to be situated in the middle of each
     slice. Extrapolation situations are handled by simple repeating.
-    
+
     Interpolation of new slices is performed using shape based interpolation.
-    
+
     Parameters
     ----------
     img : array_like
@@ -131,7 +131,7 @@ def shape_based_slice_interpolation(img, dim, nslices):
         The dimension along which to add slices.
     nslices : int
         The number of slices to add. Must be an even number.
-    
+
     Returns
     -------
     out : ndarray
@@ -140,32 +140,32 @@ def shape_based_slice_interpolation(img, dim, nslices):
     # check arguments
     if not 0 == nslices % 2:
         raise ValueError('nslices must be an even number')
-    
+
     out = None
     slicer = [slice(None)] * img.ndim
     chunk_full_shape = list(img.shape)
     chunk_full_shape[dim] = nslices + 2
-     
+
     for sl1, sl2 in zip(numpy.rollaxis(img, dim)[:-1], numpy.rollaxis(img, dim)[1:]):
         if 0 == numpy.count_nonzero(sl1) and 0 == numpy.count_nonzero(sl2):
-            chunk = numpy.zeros(chunk_full_shape, dtype=numpy.bool)
+            chunk = numpy.zeros(chunk_full_shape, dtype=numpy.bool_)
         else:
             chunk = shape_based_slice_insertation_object_wise(sl1, sl2, dim, nslices)
         if out is None:
             out = numpy.delete(chunk, -1, dim)
         else:
             out = numpy.concatenate((out, numpy.delete(chunk, -1, dim)), dim)
-    
-    slicer[dim] = numpy.newaxis    
+
+    slicer[dim] = numpy.newaxis
     out = numpy.concatenate((out, sl2[slicer]), dim)
-    
+
     slicer[dim] = slice(0, 1)
     for _ in range(nslices // 2):
         out = numpy.concatenate((img[slicer], out), dim)
     slicer[dim] = slice(-1, None)
     for _ in range(nslices // 2):
         out = numpy.concatenate((out, img[slicer]), dim)
-        
+
     return out
 
 def shape_based_slice_insertation_object_wise(sl1, sl2, dim, nslices, order=3):
@@ -184,15 +184,15 @@ def shape_based_slice_insertation_object_wise(sl1, sl2, dim, nslices, order=3):
         else:
             out |= _out
     return out
-    
+
 def shape_based_slice_insertation(sl1, sl2, dim, nslices, order=3):
     """
     Insert `nslices` new slices between `sl1` and `sl2` along dimension `dim` using shape
     based binary interpolation.
-    
+
     Extrapolation is handled adding `nslices`/2 step-wise eroded copies of the last slice
     in each direction.
-    
+
     Parameters
     ----------
     sl1 : array_like
@@ -205,16 +205,16 @@ def shape_based_slice_insertation(sl1, sl2, dim, nslices, order=3):
         The number of slices to add.
     order : int
         The b-spline interpolation order for re-sampling the distance maps.
-        
+
     Returns
     -------
     out : ndarray
         A binary image of size `sl1`.shape() extend by `nslices`+2 along the new
         dimension `dim`. The border slices are the original slices `sl1` and `sl2`.
     """
-    sl1 = sl1.astype(numpy.bool)
-    sl2 = sl2.astype(numpy.bool)
-    
+    sl1 = sl1.astype(numpy.bool_)
+    sl2 = sl2.astype(numpy.bool_)
+
     # extrapolation through erosion
     if 0 == numpy.count_nonzero(sl1):
         slices = [sl1]
@@ -234,26 +234,26 @@ def shape_based_slice_insertation(sl1, sl2, dim, nslices, order=3):
         slices.append(sl2)
         return numpy.rollaxis(numpy.asarray(slices), 0, dim + 1)
         #return numpy.asarray([sl.T for sl in slices]).T
-    
-    # interpolation shape based 
+
+    # interpolation shape based
     # note: distance_transform_edt shows strange behaviour for ones-arrays
     dt1 = distance_transform_edt(~sl1) - distance_transform_edt(sl1)
     dt2 = distance_transform_edt(~sl2) - distance_transform_edt(sl2)
-    
+
     slicer = [slice(None)] * dt1.ndim
     slicer = slicer[:dim] + [numpy.newaxis] + slicer[dim:]
     out = numpy.concatenate((dt1[slicer], dt2[slicer]), axis=dim)
     zoom_factors = [1] * dt1.ndim
     zoom_factors = zoom_factors[:dim] + [(nslices + 2)/2.] + zoom_factors[dim:]
     out = zoom(out, zoom_factors, order=order)
-    
+
     return out <= 0
-    
+
 def getArguments(parser):
     "Provides additional validation of the arguments collected by argparse."
     args = parser.parse_args()
     if args.order < 0 or args.order > 5:
-        parser.error('The order has to be a number between 0 and 5.')   
+        parser.error('The order has to be a number between 0 and 5.')
     return args
 
 def getParser():
@@ -268,6 +268,6 @@ def getParser():
     parser.add_argument('-d', dest='debug', action='store_true', help='Display debug information.')
     parser.add_argument('-f', '--force', dest='force', action='store_true', help='overwrite existing files')
     return parser
-    
+
 if __name__ == "__main__":
-    main()    
+    main()

--- a/bin/medpy_extract_contour.py
+++ b/bin/medpy_extract_contour.py
@@ -46,16 +46,16 @@ __description__ = """
                   contour width, the surface of the volume will correspond with the
                   middle of the contour line. In the case of an odd contour width, the
                   contour will be shifted by one voxel towards the inside of the volume.
-                  
+
                   In the case of 3D volumes, the contours result in shells, which might
                   not be desired, as they do not visualize well in 2D views. With the
                   '--dimension' argument, a dimension along which to extract the contours
                   can be supplied.
-                  
+
                   Copyright (C) 2013 Oskar Maier
                   This program comes with ABSOLUTELY NO WARRANTY; This is free software,
                   and you are welcome to redistribute it under certain conditions; see
-                  the LICENSE file or <http://www.gnu.org/licenses/> for details.   
+                  the LICENSE file or <http://www.gnu.org/licenses/> for details.
                   """
 
 # code
@@ -66,22 +66,22 @@ def main():
     logger = Logger.getInstance()
     if args.debug: logger.setLevel(logging.DEBUG)
     elif args.verbose: logger.setLevel(logging.INFO)
-    
+
     # load input image
     data_input, header_input = load(args.input)
-    
+
     # treat as binary
-    data_input = data_input.astype(numpy.bool)
-    
+    data_input = data_input.astype(numpy.bool_)
+
     # check dimension argument
     if args.dimension and (not args.dimension >= 0 or not args.dimension < data_input.ndim):
         argparse.ArgumentError(args.dimension, 'Invalid dimension of {} supplied. Image has only {} dimensions.'.format(args.dimension, data_input.ndim))
-        
+
     # compute erosion and dilation steps
     erosions = int(math.ceil(args.width / 2.))
     dilations = int(math.floor(args.width / 2.))
     logger.debug("Performing {} erosions and {} dilations to achieve a contour of width {}.".format(erosions, dilations, args.width))
-    
+
     # erode, dilate and compute contour
     if not args.dimension:
         eroded = binary_erosion(data_input, iterations=erosions) if not 0 == erosions else data_input
@@ -95,7 +95,7 @@ def main():
             slicer[args.dimension] = slice(sl, sl+1)
             bs_slicer[args.dimension] = slice(1, 2)
             bs = generate_binary_structure(data_input.ndim, 1)
-            
+
             eroded = binary_erosion(data_input[slicer], structure=bs[bs_slicer], iterations=erosions) if not 0 == erosions else data_input[slicer]
             dilated = binary_dilation(data_input[slicer], structure=bs[bs_slicer], iterations=dilations) if not 0 == dilations else data_input[slicer]
             data_output[slicer] = dilated - eroded
@@ -103,9 +103,9 @@ def main():
 
     # save resulting volume
     save(data_output, args.output, header_input, args.force)
-    
-    logger.info("Successfully terminated.")    
-    
+
+    logger.info("Successfully terminated.")
+
 def getArguments(parser):
     "Provides additional validation of the arguments collected by argparse."
     args = parser.parse_args()
@@ -123,7 +123,7 @@ def getParser():
     parser.add_argument('-v', dest='verbose', action='store_true', help='Display more information.')
     parser.add_argument('-d', dest='debug', action='store_true', help='Display debug information.')
     parser.add_argument('-f', dest='force', action='store_true', help='Silently override existing output images.')
-    return parser    
+    return parser
 
 if __name__ == "__main__":
-    main()        
+    main()

--- a/bin/medpy_intensity_range_standardization.py
+++ b/bin/medpy_intensity_range_standardization.py
@@ -49,7 +49,7 @@ Standardizes the intensity range / profile of a number of similar images.
 Takes a number of images that display the same scene (most commonly MRI volumes of the
 same body region) and learns an average intensity range model from these. This model can
 then be used to transfer the training image set and other, formerly unseen images, to the
-learned average intensity range. Such prepared, these images display the same intensity 
+learned average intensity range. Such prepared, these images display the same intensity
 profiles for the same structures.
 
 The employed algorithm guarantees a lossless intensity transformation and throws an
@@ -69,13 +69,13 @@ The implementation is based on:
 [1] Nyul, L.G.; Udupa, J.K.; Xuan Zhang, "New variants of a method of MRI scale
     standardization," Medical Imaging, IEEE Transactions on , vol.19, no.2, pp.143-150,
     Feb. 2000
-    
+
 For more details on the algorithm, see the medpy.filter.IntensityRangeStandardization class.
 
 Copyright (C) 2013 Oskar Maier
 This program comes with ABSOLUTELY NO WARRANTY; This is free software,
 and you are welcome to redistribute it under certain conditions; see
-the LICENSE file or <http://www.gnu.org/licenses/> for details.   
+the LICENSE file or <http://www.gnu.org/licenses/> for details.
                   """
 
 # code
@@ -86,7 +86,7 @@ def main():
     logger = Logger.getInstance()
     if args.debug: logger.setLevel(logging.DEBUG)
     elif args.verbose: logger.setLevel(logging.INFO)
-    
+
     # loading input images (as image, header pairs)
     images = []
     headers = []
@@ -94,13 +94,13 @@ def main():
         i, h = load(image_name)
         images.append(i)
         headers.append(h)
-    
+
     # loading binary foreground masks if supplied, else create masks from threshold value
     if args.masks:
-        masks = [load(mask_name)[0].astype(numpy.bool) for mask_name in args.masks]
+        masks = [load(mask_name)[0].astype(numpy.bool_) for mask_name in args.masks]
     else:
         masks = [i > args.threshold for i in images]
-    
+
     # if in application mode, load the supplied model and apply it to the images
     if args.lmodel:
         logger.info('Loading the model and transforming images...')
@@ -109,7 +109,7 @@ def main():
             if not isinstance(trained_model, IntensityRangeStandardization):
                 raise ArgumentError('{} does not seem to be a valid pickled instance of an IntensityRangeStandardization object'.format(args.lmodel))
             transformed_images = [trained_model.transform(i[m], surpress_mapping_check = args.ignore) for i, m in zip(images, masks)]
-            
+
     # in in training mode, train the model, apply it to the images and save it
     else:
         logger.info('Training the average intensity model...')
@@ -118,35 +118,35 @@ def main():
         logger.info('Saving the trained model as {}...'.format(args.smodel))
         with open(args.smodel, 'wb') as f:
                 pickle.dump(trained_model, f)
-                
+
     # save the transformed images
     if args.simages:
         logger.info('Saving intensity transformed images to {}...'.format(args.simages))
         for ti, i, m, h, image_name in zip(transformed_images, images, masks, headers, args.images):
             i[m] = ti
             save(i, '{}/{}'.format(args.simages, image_name.split('/')[-1]), h, args.force)
-    
-    logger.info('Terminated.')
-    
 
-    
+    logger.info('Terminated.')
+
+
+
 def getArguments(parser):
     "Provides additional validation of the arguments collected by argparse."
     args = parser.parse_args()
-    
+
     # check mutual exlusive and reaquired arguments
     if args.lmodel and args.smodel:
         parser.error('only one of --load-model and --save-model can be supplied, as they decide on whether to apply the application or the training mode')
     if not args.lmodel and not args.smodel:
         parser.error('exactly one of --load-model or --save-model has to be supplied')
-    
+
     # application mode
     if args.lmodel:
         if not os.path.isfile(args.lmodel):
             parser.error('the supplied model file {} does not exist'.format(args.lmodel))
         if not args.simages:
             parser.error('--save-images must be supplied when running the application mode')
-    
+
     # training mode
     if args.smodel:
         if not args.landmarkp in ('L2', 'L3', 'L4'):
@@ -155,14 +155,14 @@ def getArguments(parser):
             args.stdspace = sequenceOfIntegersGeAscendingStrict(args.stdspace)
         if not args.force and os.path.isfile(args.smodel):
             parser.error('the target model file {} already exists'.format(args.smodel))
-        
+
     # others
     if args.simages:
         if not os.path.isdir(args.simages):
             parser.error('--save-images must be a valid directory')
     if args.masks and len(args.masks) != len(args.images):
-        parser.error('the same number of masks must be passed to --masks as images have been supplied') 
-    
+        parser.error('the same number of masks must be passed to --masks as images have been supplied')
+
     return args
 
 def getParser():
@@ -172,23 +172,23 @@ def getParser():
 
     apply_group = parser.add_argument_group('apply an existing model')
     apply_group.add_argument('--load-model', dest='lmodel', default=False, help='Location of the pickled intensity range model to load. Activated application mode.')
-    
+
     train_group = parser.add_argument_group('train a new model and save and/or apply it')
     train_group.add_argument('--save-model', dest='smodel', default=False, help='Save the trained model under this name as a pickled object (should end in .pkl). Activates training mode.')
     train_group.add_argument('--cutoffp', dest='cutoffp', type=sequenceOfIntegersGeAscendingStrict, default='1,99', help='Colon-separated lower and upper cut-off percentile values to exclude intensity outliers during the model training.')
     train_group.add_argument('--landmarkp', dest='landmarkp', default='L4', help='The landmark percentiles, based on which to train the model. Can be L2, L3, L4 or a colon-separated, ordered list of percentiles.')
     train_group.add_argument('--stdspace', dest='stdspace', default='auto', help='Two colon-separated intensity values to roughly define the average intensity space to learn. In most cases should be left set to \'auto\'')
-    
+
     shared_group = parser.add_argument_group('shared arguments')
     shared_group.add_argument('--save-images', dest='simages', default=False, help='Save the transformed images under this location. Required for the application mode, optional for the learning mode.')
     shared_group.add_argument('--threshold', type=float, default=0, help='All voxel with an intensity > threshold are considered as foreground. Supply either this or a mask for each image.')
     shared_group.add_argument('--masks', nargs='+', help='A number of binary foreground mask, one for each image. Alternative to supplying a threshold. Overrides the threshold parameter if supplied.')
     shared_group.add_argument('--ignore', dest='ignore', action='store_true', help='Ignore possible loss of information during the intensity transformation. Should only be used when you know what you are doing.')
-    
+
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='Verbose output')
     parser.add_argument('-d', '--debug', dest='debug', action='store_true', help='Display debug information.')
     parser.add_argument('-f', '--force', dest='force', action='store_true', help='Overwrite existing files (both model and images)')
     return parser
-    
+
 if __name__ == "__main__":
-    main()        
+    main()

--- a/bin/medpy_label_fit_to_mask.py
+++ b/bin/medpy_label_fit_to_mask.py
@@ -30,7 +30,7 @@ import numpy
 # path changes
 
 # own modules
-from medpy.io import load, save 
+from medpy.io import load, save
 from medpy.core import Logger
 from medpy.filter import fit_labels_to_mask
 
@@ -49,11 +49,11 @@ __description__ = """
                   and if the value exceeds 50% of the total region size, it is marked
                   as mask, otherwise as background. For more details on how the fitting
                   is performed @see filter.fit_labels_to_mask.
-                  
+
                   Copyright (C) 2013 Oskar Maier
                   This program comes with ABSOLUTELY NO WARRANTY; This is free software,
                   and you are welcome to redistribute it under certain conditions; see
-                  the LICENSE file or <http://www.gnu.org/licenses/> for details.   
+                  the LICENSE file or <http://www.gnu.org/licenses/> for details.
                   """
 
 # code
@@ -62,36 +62,36 @@ def main():
     parser = getParser()
     parser.parse_args()
     args = getArguments(parser)
-    
+
     # prepare logger
     logger = Logger.getInstance()
     if args.debug: logger.setLevel(logging.DEBUG)
     elif args.verbose: logger.setLevel(logging.INFO)
-    
+
     # load input image
     logger.info('Loading image {}...'.format(args.input))
-    image_labels_data, _ = load(args.image)    
-    
+    image_labels_data, _ = load(args.image)
+
     # load mask image
     logger.info('Loading mask {}...'.format(args.mask))
     image_mask_data, image_mask_data_header = load(args.mask)
-    
+
     # check if output image exists
     if not args.force:
         if os.path.exists(args.output):
             logger.warning('The output image {} already exists. Skipping this image.'.format(args.output))
-    
+
     # create a mask from the label image
     logger.info('Reducing the label image...')
     image_reduced_data = fit_labels_to_mask(image_labels_data, image_mask_data)
-    
+
     # save resulting mask
     logger.info('Saving resulting mask as {} in the same format as input mask, only with data-type int8...'.format(args.output))
-    image_reduced_data = image_reduced_data.astype(numpy.bool, copy=False) # bool sadly not recognized
+    image_reduced_data = image_reduced_data.astype(numpy.bool_, copy=False) # bool sadly not recognized
     save(image_reduced_data, args.output, image_mask_data_header, args.force)
-    
+
     logger.info('Successfully terminated.')
-        
+
 def getArguments(parser):
     "Provides additional validation of the arguments collected by argparse."
     return parser.parse_args()
@@ -106,8 +106,8 @@ def getParser():
     parser.add_argument('-v', dest='verbose', action='store_true', help='Display more information.')
     parser.add_argument('-d', dest='debug', action='store_true', help='Display debug information.')
     parser.add_argument('-f', dest='force', action='store_true', help='Silently override existing output images.')
-    
-    return parser    
-    
+
+    return parser
+
 if __name__ == "__main__":
-    main()        
+    main()

--- a/bin/medpy_watershed.py
+++ b/bin/medpy_watershed.py
@@ -47,11 +47,11 @@ __description__ = """
                   Applies the watershed segmentation an image using the supplied
                   parameters.
                   Note that this version does not take the voxel-spacing into account.
-                                  
+
                   Copyright (C) 2013 Oskar Maier
                   This program comes with ABSOLUTELY NO WARRANTY; This is free software,
                   and you are welcome to redistribute it under certain conditions; see
-                  the LICENSE file or <http://www.gnu.org/licenses/> for details.   
+                  the LICENSE file or <http://www.gnu.org/licenses/> for details.
                   """
 
 # code
@@ -60,24 +60,24 @@ def main():
     parser = getParser()
     parser.parse_args()
     args = getArguments(parser)
-    
+
     # prepare logger
     logger = Logger.getInstance()
     if args.debug: logger.setLevel(logging.DEBUG)
     elif args.verbose: logger.setLevel(logging.INFO)
-    
+
     # check if output image exists (will also be performed before saving, but as the watershed might be very time intensity, a initial check can save frustration)
     if not args.force:
         if os.path.exists(args.output):
             raise ArgumentError('The output image {} already exists.'.format(args.output))
-    
+
     # loading images
     data_input, header_input = load(args.input)
     if args.mask:
-        mask = load(args.mask)[0].astype(numpy.bool)
+        mask = load(args.mask)[0].astype(numpy.bool_)
     else:
         mask = None
-    
+
     # extract local minima and convert to markers
     logger.info('Extract local minima with minimum distance of {}...'.format(args.mindist))
     lm, _ = local_minima(data_input, args.mindist)
@@ -87,14 +87,14 @@ def main():
     if not None == mask:
         minima_labels[~mask] = 0
     minima_labels, _ = label(minima_labels)
-    
+
     # apply the watershed
     logger.info('Watershedding...')
     data_output = watershed(data_input, minima_labels, mask=mask)
 
     # save file
     save(data_output, args.output, header_input, args.force)
-    
+
     logger.info('Successfully terminated.')
 
 def getArguments(parser):
@@ -111,8 +111,8 @@ def getParser():
     parser.add_argument('-v', dest='verbose', action='store_true', help='Display more information.')
     parser.add_argument('-d', dest='debug', action='store_true', help='Display debug information.')
     parser.add_argument('-f', dest='force', action='store_true', help='Silently override existing output images.')
-    
+
     return parser
-    
+
 if __name__ == "__main__":
     main()

--- a/medpy/features/intensity.py
+++ b/medpy/features/intensity.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -38,17 +38,17 @@ from ..filter import sum_filter
 def intensities(image, mask = slice(None)):
     r"""Takes a simple or multi-spectral image and returns its voxel-wise intensities.
     A multi-spectral image must be supplied as a list or tuple of its spectra.
-    
+
     Optionally a binary mask can be supplied to select the voxels for which the feature
     should be extracted.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     mask : array_like
         A binary mask for the image.
-    
+
     Returns
     -------
     intensities : ndarray
@@ -60,20 +60,20 @@ def centerdistance(image, voxelspacing = None, mask = slice(None)):
     r"""
     Takes a simple or multi-spectral image and returns its voxel-wise center distance in
     mm. A multi-spectral image must be supplied as a list or tuple of its spectra.
-    
+
     Optionally a binary mask can be supplied to select the voxels for which the feature
     should be extracted.
-    
+
     The center distance is the exact euclidean distance in mm of each voxels center to
     the central point of the overal image volume.
-    
+
     Note that this feature is independent of the actual image content, but depends
     solely on its shape. Therefore always a one-dimensional feature is returned, even if
-    a multi-spectral image has been supplied. 
+    a multi-spectral image has been supplied.
 
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     voxelspacing : sequence of floats
         The side-length of each voxel.
@@ -84,27 +84,27 @@ def centerdistance(image, voxelspacing = None, mask = slice(None)):
     -------
     centerdistance : ndarray
         The distance of each voxel to the images center.
-        
+
     See Also
     --------
     centerdistance_xdminus1
-    
+
     """
     if type(image) == tuple or type(image) == list:
         image = image[0]
-        
+
     return _extract_feature(_extract_centerdistance, image, mask, voxelspacing = voxelspacing)
 
 def centerdistance_xdminus1(image, dim, voxelspacing = None, mask = slice(None)):
     r"""
     Implementation of `centerdistance` that allows to compute sub-volume wise
     centerdistances.
-    
+
     The same notes as for `centerdistance` apply.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     dim : int or sequence of ints
         The dimension or dimensions along which to cut the image into sub-volumes.
@@ -112,12 +112,12 @@ def centerdistance_xdminus1(image, dim, voxelspacing = None, mask = slice(None))
         The side-length of each voxel.
     mask : array_like
         A binary mask for the image.
-    
+
     Returns
     -------
     centerdistance_xdminus1 : ndarray
         The distance of each voxel to the images center in the supplied dimensions.
-    
+
     Raises
     ------
     ArgumentError
@@ -128,41 +128,41 @@ def centerdistance_xdminus1(image, dim, voxelspacing = None, mask = slice(None))
     Considering a 3D medical image we want to compute the axial slice-wise
     centerdistances instead of the ones over the complete image volume. Assuming that
     the third image dimension corresponds to the axial axes of the image, we call
-        
+
     >>> centerdistance_xdminus1(image, 2)
-    
+
     Note that the centerdistance of each slice will be equal.
 
     """
     # pre-process arguments
     if type(image) == tuple or type(image) == list:
         image = image[0]
-    
+
     if type(dim) is int:
         dims = [dim]
     else:
         dims = list(dim)
-        
+
     # check arguments
     if len(dims) >= image.ndim - 1:
         raise ArgumentError('Applying a sub-volume extraction of depth {} on a image of dimensionality {} would lead to invalid images of dimensionality <= 1.'.format(len(dims), image.ndim))
     for dim in dims:
         if dim >= image.ndim:
             raise ArgumentError('Invalid dimension index {} supplied for image(s) of shape {}.'.format(dim, image.shape))
-    
+
     # extract desired sub-volume
     slicer = [slice(None)] * image.ndim
     for dim in dims: slicer[dim] = slice(1)
     subvolume = numpy.squeeze(image[slicer])
-    
+
     # compute centerdistance for sub-volume and reshape to original sub-volume shape (note that normalization and mask are not passed on in this step)
     o = centerdistance(subvolume, voxelspacing).reshape(subvolume.shape)
-    
+
     # re-establish original shape by copying the resulting array multiple times
     for dim in sorted(dims):
         o = numpy.asarray([o] * image.shape[dim])
         o = numpy.rollaxis(o, 0, dim + 1)
-        
+
     # extract intensities / centerdistance values, applying normalization and mask in this step
     return intensities(o, mask)
 
@@ -171,19 +171,19 @@ def indices(image, voxelspacing = None, mask = slice(None)):
     Takes an image and returns the voxels ndim-indices as voxel-wise feature. The voxel
     spacing is taken into account, i.e. the indices are not array indices, but millimeter
     indices.
-    
+
     This is a multi-element feature where each element corresponds to one of the images
     axes, e.g. x, y, z, ...
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     voxelspacing : sequence of floats
         The side-length of each voxel.
     mask : array_like
-        A binary mask for the image. 
-    
+        A binary mask for the image.
+
     Returns
     -------
     indices : ndarray
@@ -194,30 +194,30 @@ def indices(image, voxelspacing = None, mask = slice(None)):
     This feature is independent of the actual image content, but depends
     solely on its shape. Therefore always a one-dimensional feature is returned, even if
     a multi-spectral image has been supplied.
-    
+
     """
     if type(image) == tuple or type(image) == list:
         image = image[0]
-        
+
     if not type(mask) is slice:
-        mask = numpy.array(mask, copy=False, dtype=numpy.bool)
-        
+        mask = numpy.array(mask, copy=False, dtype=numpy.bool_)
+
     if voxelspacing is None:
         voxelspacing = [1.] * image.ndim
 
     return join(*[a[mask].ravel() * vs for a, vs in zip(numpy.indices(image.shape), voxelspacing)])
-    
+
 def shifted_mean_gauss(image, offset = None, sigma = 5, voxelspacing = None, mask = slice(None)):
     r"""
     The approximate mean over a small region at an offset from each voxel.
-    
+
     Functions like `local_mean_gauss`, but instead of computing the average over a small
     patch around the current voxel, the region is centered at an offset away. Can be used
     to use a distant regions average as feature for a voxel.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     offset : sequence of ints
         At this offset in voxels of the current position the region is placed.
@@ -229,40 +229,40 @@ def shifted_mean_gauss(image, offset = None, sigma = 5, voxelspacing = None, mas
     voxelspacing : sequence of floats
         The side-length of each voxel.
     mask : array_like
-        A binary mask for the image. 
-    
+        A binary mask for the image.
+
     Returns
     -------
     shifted_mean_gauss : ndarray
         The weighted mean intensities over a region at offset away from each voxel.
-    
+
     See also
     --------
     local_mean_gauss
-    
+
     """
     return _extract_feature(_extract_shifted_mean_gauss, image, mask, offset = offset, sigma = sigma, voxelspacing = voxelspacing)
-    
+
 def mask_distance(image, voxelspacing = None, mask = slice(None)):
     r"""
     Computes the distance of each point under the mask to the mask border taking the
     voxel-spacing into account.
-    
+
     Note that this feature is independent of the actual image content, but depends
     solely the mask image. Therefore always a one-dimensional feature is returned,
     even if a multi-spectral image has been supplied.
-    
+
     If no mask has been supplied, the distances to the image borders are returned.
 
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     voxelspacing : sequence of floats
         The side-length of each voxel.
     mask : array_like
-        A binary mask for the image.     
-    
+        A binary mask for the image.
+
     Returns
     -------
     mask_distance : ndarray
@@ -271,42 +271,42 @@ def mask_distance(image, voxelspacing = None, mask = slice(None)):
     """
     if type(image) == tuple or type(image) == list:
         image = image[0]
-        
+
     return _extract_mask_distance(image, mask = mask, voxelspacing = voxelspacing)
-    
+
 def local_mean_gauss(image, sigma = 5, voxelspacing = None, mask = slice(None)):
     r"""
     Takes a simple or multi-spectral image and returns the approximate mean over a small
     region around each voxel. A multi-spectral image must be supplied as a list or tuple
     of its spectra.
-    
+
     Optionally a binary mask can be supplied to select the voxels for which the feature
     should be extracted.
-    
+
     For this feature a Gaussian smoothing filter is applied to the image / each spectrum
     and then the resulting intensity values returned. Another name for this function
     would be weighted local mean.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     sigma : number or sequence of numbers
         Standard deviation for Gaussian kernel. The standard deviations of the
         Gaussian filter are given for each axis as a sequence, or as a single number,
         in which case it is equal for all axes. Note that the voxel spacing of the image
-        is taken into account, the given values are treated as mm.        
+        is taken into account, the given values are treated as mm.
     voxelspacing : sequence of floats
         The side-length of each voxel.
     mask : array_like
-        A binary mask for the image.       
-    
-    
+        A binary mask for the image.
+
+
     Returns
     -------
     local_mean_gauss : ndarray
         The weighted mean intensities over a region around each voxel.
-    
+
     """
     return _extract_feature(_extract_local_mean_gauss, image, mask, sigma = sigma, voxelspacing = voxelspacing)
 
@@ -314,29 +314,29 @@ def gaussian_gradient_magnitude(image, sigma = 5, voxelspacing = None, mask = sl
     r"""
     Computes the gradient magnitude (edge-detection) of the supplied image using gaussian
     derivates and returns the intensity values.
-    
+
     Optionally a binary mask can be supplied to select the voxels for which the feature
     should be extracted.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     sigma : number or sequence of numbers
         Standard deviation for Gaussian kernel. The standard deviations of the
         Gaussian filter are given for each axis as a sequence, or as a single number,
         in which case it is equal for all axes. Note that the voxel spacing of the image
-        is taken into account, the given values are treated as mm.        
+        is taken into account, the given values are treated as mm.
     voxelspacing : sequence of floats
         The side-length of each voxel.
     mask : array_like
-        A binary mask for the image.          
+        A binary mask for the image.
 
     Returns
     -------
     gaussian_gradient_magnitude : ndarray
         The gaussian gradient magnitude of the supplied image.
-    
+
     """
     return _extract_feature(_extract_gaussian_gradient_magnitude, image, mask, sigma = sigma, voxelspacing = voxelspacing)
 
@@ -344,13 +344,13 @@ def median(image, size = 5, voxelspacing = None, mask = slice(None)):
     """
     Computes the multi-dimensional median filter and returns the resulting values per
     voxel.
-    
+
     Optionally a binary mask can be supplied to select the voxels for which the feature
     should be extracted.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     size : number or sequence of numbers
         Size of the structuring element. Can be given given for each axis as a sequence,
@@ -361,59 +361,59 @@ def median(image, size = 5, voxelspacing = None, mask = slice(None)):
         The side-length of each voxel.
     mask : array_like
         A binary mask for the image.
-        
+
     Returns
     -------
     median : ndarray
         Multi-dimesnional median filtered version of the input images.
-    
+
     """
     return _extract_feature(_extract_median, image, mask, size = size, voxelspacing = voxelspacing)
 
 def local_histogram(image, bins=19, rang="image", cutoffp=(0.0, 100.0), size=None, footprint=None, output=None, mode="ignore", origin=0, mask=slice(None)):
     r"""
     Computes multi-dimensional histograms over a region around each voxel.
-    
+
     Supply an image and (optionally) a mask and get the local histogram of local
     neighbourhoods around each voxel. These neighbourhoods are cubic with a sidelength of
     size in voxels or, when a shape instead of an integer is passed to size, of this
     shape.
-    
+
     If not argument is passed to output, the returned array will be of dtype float.
-    
+
     Voxels along the image border are treated as defined by mode. The possible values are
     the same as for scipy.ndimage filter without the ''constant'' mode. Instead "ignore"
     is the default and additional mode, which sets that the area outside of the image are
     ignored when computing the histogram.
-    
+
     When a mask is supplied, the local histogram is extracted only for the voxels where
     the mask is True. But voxels from outside the mask can be incorporated in the
     compuation of the histograms.
-    
+
     The range of the histograms can be set via the rang argument. The 'image' keyword can
     be supplied, to use the same range for all local histograms, extracted from the images
     max and min intensity values. Alternatively, an own range can be supplied in the form
     of a tuple of two numbers. Values outside the range of the histogram are ignored.
-    
+
     Setting a proper range is important, as all voxels that lie outside of the range are
     ignored i.e. do not contribute to the histograms as if they would not exists. Some
     of the local histograms can therefore be constructed from less than the expected
     number of voxels.
-    
+
     Taking the histogram range from the whole image is sensitive to outliers. Supplying
     percentile values to the cutoffp argument, these can be filtered out when computing
     the range. This keyword is ignored if rang is not set to 'image'.
-    
+
     Setting the rang to None causes local ranges to be used i.e. the ranges of the
     histograms are computed only over the local area covered by them and are hence
     not comparable. This behaviour should normally not be taken.
-    
+
     The local histograms are normalized by dividing them through the number of elements
     in the bins.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     bins : integer
         The number of histogram bins.
@@ -442,25 +442,25 @@ def local_histogram(image, bins=19, rang="image", cutoffp=(0.0, 100.0), size=Non
         The ``origin`` parameter controls the placement of the filter. Default 0.
     mask : array_like
         A binary mask for the image.
-        
+
     Returns
     -------
     local_histogram : ndarray
         The bin values of the local histograms for each voxel as a multi-dimensional image.
 
-    """    
+    """
     return _extract_feature(_extract_local_histogram, image, mask, bins=bins, rang=rang, cutoffp=cutoffp, size=size, footprint=footprint, output=output, mode=mode, origin=origin)
 
 
 def hemispheric_difference(image, sigma_active = 7, sigma_reference = 7, cut_plane = 0, voxelspacing = None, mask = slice(None)):
     r"""
     Computes the hemispheric intensity difference between the brain hemispheres of an brain image.
-    
+
     Cuts the image along the middle of the supplied cut-plane. This results in two
     images, each containing one of the brains hemispheres.
-    
+
     For each of these two, the following steps are applied:
-    
+
     1. One image is marked as active image
     2. The other hemisphere image is marked as reference image
     3. The reference image is fliped along the cut_plane
@@ -468,20 +468,20 @@ def hemispheric_difference(image, sigma_active = 7, sigma_reference = 7, cut_pla
     5. A gaussian smoothing is applied to the reference image with the supplied sigma
     6. The reference image is substracted from the active image, resulting in the
        difference image for the active hemisphere
-    
+
     Finally, the two resulting difference images are stitched back together, forming a
     hemispheric difference image of the same size as the original.
-    
+
     Note that the supplied gaussian kernel sizes (sigmas) are sensitive to the images
     voxel spacing.
-    
+
     If the number of slices along the cut-plane is odd, the central slice is
     interpolated from the two hemisphere difference images when stitching them back
     together.
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     sigma_active : number or sequence of numbers
         Standard deviation for Gaussian kernel of the active image. The standard
@@ -501,21 +501,21 @@ def hemispheric_difference(image, sigma_active = 7, sigma_reference = 7, cut_pla
         The side-length of each voxel.
     mask : array_like
         A binary mask for the image.
-        
+
     Returns
     -------
     hemispheric_difference : ndarray
         The intensity differences between the locally smoothed hemispheres of the image.
         The resulting voxel value's magnitude denotes symmetrical its asymmetry. The
         direction is revealed by the sign. That means that the resulting image will be
-        symmetric in absolute values, but differ in sign. 
+        symmetric in absolute values, but differ in sign.
 
     Raises
     ------
     ArgumentError
         If the supplied cut-plane dimension is invalid.
 
-    """   
+    """
     return _extract_feature(_extract_hemispheric_difference, image, mask, sigma_active = sigma_active, sigma_reference = sigma_reference, cut_plane = cut_plane, voxelspacing = voxelspacing)
 
 
@@ -525,19 +525,19 @@ def _extract_hemispheric_difference(image, mask = slice(None), sigma_active = 7,
     """
     # constants
     INTERPOLATION_RANGE = int(10) # how many neighbouring values to take into account when interpolating the medial longitudinal fissure slice
-    
+
     # check arguments
     if cut_plane >= image.ndim:
         raise ArgumentError('The suppliedc cut-plane ({}) is invalid, the image has only {} dimensions.'.format(cut_plane, image.ndim))
-    
+
     # set voxel spacing
     if voxelspacing is None:
         voxelspacing = [1.] * image.ndim
-    
+
     # compute the (presumed) location of the medial longitudinal fissure, treating also the special of an odd number of slices, in which case a cut into two equal halves is not possible
     medial_longitudinal_fissure = int(image.shape[cut_plane] / 2)
     medial_longitudinal_fissure_excluded = image.shape[cut_plane] % 2
-    
+
     # split the head into a dexter and sinister half along the saggital plane
     # this is assumed to be consistent with a cut of the brain along the medial longitudinal fissure, thus separating it into its hemispheres
     slicer = [slice(None)] * image.ndim
@@ -546,7 +546,7 @@ def _extract_hemispheric_difference(image, mask = slice(None), sigma_active = 7,
 
     slicer[cut_plane] = slice(medial_longitudinal_fissure + medial_longitudinal_fissure_excluded, None)
     right_hemisphere = image[slicer]
-    
+
     # flip right hemisphere image along cut plane
     slicer[cut_plane] = slice(None, None, -1)
     right_hemisphere = right_hemisphere[slicer]
@@ -554,10 +554,10 @@ def _extract_hemispheric_difference(image, mask = slice(None), sigma_active = 7,
     # substract once left from right and once right from left hemisphere, including smoothing steps
     right_hemisphere_difference = _substract_hemispheres(right_hemisphere, left_hemisphere, sigma_active, sigma_reference, voxelspacing)
     left_hemisphere_difference = _substract_hemispheres(left_hemisphere, right_hemisphere, sigma_active, sigma_reference, voxelspacing)
-    
+
     # re-flip right hemisphere image to original orientation
     right_hemisphere_difference = right_hemisphere_difference[slicer]
-    
+
     # estimate the medial longitudinal fissure if required
     if 1 == medial_longitudinal_fissure_excluded:
         left_slicer = [slice(None)] * image.ndim
@@ -587,7 +587,7 @@ def _extract_hemispheric_difference(image, mask = slice(None), sigma_active = 7,
 def _extract_local_histogram(image, mask=slice(None), bins=19, rang="image", cutoffp=(0.0, 100.0), size=None, footprint=None, output=None, mode="ignore", origin=0):
     """
     Internal, single-image version of @see local_histogram
-    
+
     Note: Values outside of the histograms range are not considered.
     Note: Mode constant is not available, instead a mode "ignore" is provided.
     Note: Default dtype of returned values is float.
@@ -600,9 +600,9 @@ def _extract_local_histogram(image, mask=slice(None), bins=19, rang="image", cut
         rang = tuple(numpy.percentile(image[mask], cutoffp))
     elif not 2 == len(rang):
         raise RuntimeError('the rang must contain exactly two elements or the string "image"')
-        
+
     _, bin_edges = numpy.histogram([], bins=bins, range=rang)
-    output = _get_output(numpy.float if None == output else output, image, shape = [bins] + list(image.shape))
+    output = _get_output(float if None == output else output, image, shape = [bins] + list(image.shape))
 
     # threshold the image into the histogram bins represented by the output images first dimension, treat last bin separately, since upper border is inclusive
     for i in range(bins - 1):
@@ -615,7 +615,7 @@ def _extract_local_histogram(image, mask=slice(None), bins=19, rang="image", cut
     divident = numpy.sum(output, 0)
     divident[0 == divident] = 1
     output /= divident
-    
+
     # Notes on modes:
     # mode=constant with a cval outside histogram range for the histogram equals a mode=constant with a cval = 0 for the sum_filter
     # mode=constant with a cval inside  histogram range for the histogram has no equal for the sum_filter (and does not make much sense)
@@ -623,7 +623,7 @@ def _extract_local_histogram(image, mask=slice(None), bins=19, rang="image", cut
 
     # treat as multi-spectral image which intensities to extracted
     return _extract_feature(_extract_intensities, [h for h in output], mask)
-    
+
 def _extract_median(image, mask = slice(None), size = 1, voxelspacing = None):
     """
     Internal, single-image version of `median`.
@@ -631,12 +631,12 @@ def _extract_median(image, mask = slice(None), size = 1, voxelspacing = None):
     # set voxel spacing
     if voxelspacing is None:
         voxelspacing = [1.] * image.ndim
-        
+
     # determine structure element size in voxel units
     size = _create_structure_array(size, voxelspacing)
-        
+
     return _extract_intensities(median_filter(image, size), mask)
-    
+
 def _extract_gaussian_gradient_magnitude(image, mask = slice(None), sigma = 1, voxelspacing = None):
     """
     Internal, single-image version of `gaussian_gradient_magnitude`.
@@ -644,29 +644,29 @@ def _extract_gaussian_gradient_magnitude(image, mask = slice(None), sigma = 1, v
     # set voxel spacing
     if voxelspacing is None:
         voxelspacing = [1.] * image.ndim
-        
+
     # determine gaussian kernel size in voxel units
     sigma = _create_structure_array(sigma, voxelspacing)
-        
+
     return _extract_intensities(scipy_gaussian_gradient_magnitude(image, sigma), mask)
-    
+
 def _extract_shifted_mean_gauss(image, mask = slice(None), offset = None, sigma = 1, voxelspacing = None):
     """
     Internal, single-image version of `shifted_mean_gauss`.
-    """    
+    """
     # set voxel spacing
     if voxelspacing is None:
         voxelspacing = [1.] * image.ndim
     # set offset
     if offset is None:
         offset = [0] * image.ndim
-    
+
     # determine gaussian kernel size in voxel units
     sigma = _create_structure_array(sigma, voxelspacing)
-    
+
     # compute smoothed version of image
     smoothed = gaussian_filter(image, sigma)
-    
+
     shifted = numpy.zeros_like(smoothed)
     in_slicer = []
     out_slicer = []
@@ -674,20 +674,20 @@ def _extract_shifted_mean_gauss(image, mask = slice(None), offset = None, sigma 
         in_slicer.append(slice(o, None))
         out_slicer.append(slice(None, -1 * o))
     shifted[out_slicer] = smoothed[in_slicer]
-    
+
     return _extract_intensities(shifted, mask)
-    
+
 def _extract_mask_distance(image, mask = slice(None), voxelspacing = None):
     """
     Internal, single-image version of `mask_distance`.
     """
     if isinstance(mask, slice):
-        mask = numpy.ones(image.shape, numpy.bool)
-    
+        mask = numpy.ones(image.shape, numpy.bool_)
+
     distance_map = distance_transform_edt(mask, sampling=voxelspacing)
-    
+
     return _extract_intensities(distance_map, mask)
-    
+
 def _extract_local_mean_gauss(image, mask = slice(None), sigma = 1, voxelspacing = None):
     """
     Internal, single-image version of `local_mean_gauss`.
@@ -695,10 +695,10 @@ def _extract_local_mean_gauss(image, mask = slice(None), sigma = 1, voxelspacing
     # set voxel spacing
     if voxelspacing is None:
         voxelspacing = [1.] * image.ndim
-        
+
     # determine gaussian kernel size in voxel units
     sigma = _create_structure_array(sigma, voxelspacing)
-        
+
     return _extract_intensities(gaussian_filter(image, sigma), mask)
 
 
@@ -707,22 +707,22 @@ def _extract_centerdistance(image, mask = slice(None), voxelspacing = None):
     Internal, single-image version of `centerdistance`.
     """
     image = numpy.array(image, copy=False)
-    
+
     if None == voxelspacing:
         voxelspacing = [1.] * image.ndim
-        
+
     # get image center and an array holding the images indices
     centers = [(x - 1) / 2. for x in image.shape]
-    indices = numpy.indices(image.shape, dtype=numpy.float)
-    
+    indices = numpy.indices(image.shape, dtype=float)
+
     # shift to center of image and correct spacing to real world coordinates
     for dim_indices, c, vs in zip(indices, centers, voxelspacing):
         dim_indices -= c
         dim_indices *= vs
-        
+
     # compute euclidean distance to image center
     return numpy.sqrt(numpy.sum(numpy.square(indices), 0))[mask].ravel()
-    
+
 
 def _extract_intensities(image, mask = slice(None)):
     """
@@ -754,27 +754,27 @@ def _create_structure_array(structure_array, voxelspacing):
         structure_array = [s / float(vs) for s, vs in zip(structure_array, voxelspacing)]
     except TypeError:
         structure_array = [structure_array / float(vs) for vs in voxelspacing]
-    
-    return structure_array    
+
+    return structure_array
 
 def _extract_feature(fun, image, mask = slice(None), **kwargs):
     """
     Convenient function to cope with multi-spectral images and feature normalization.
-    
+
     Parameters
     ----------
     fun : function
         The feature extraction function to call
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     mask : ndarray
         The binary mask to select the voxels for which to extract the feature
     kwargs : sequence
-        Additional keyword arguments to be passed to the feature extraction function 
+        Additional keyword arguments to be passed to the feature extraction function
     """
     if not type(mask) is slice:
-        mask = numpy.array(mask, copy=False, dtype=numpy.bool)
-    
+        mask = numpy.array(mask, copy=False, dtype=numpy.bool_)
+
     if type(image) == tuple or type(image) == list:
         return join(*[fun(i, mask, **kwargs) for i in image])
     else:

--- a/medpy/features/texture.py
+++ b/medpy/features/texture.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -33,62 +33,62 @@ from math import factorial
 def coarseness(image, voxelspacing = None, mask = slice(None)):
     r"""
     Takes a simple or multi-spectral image and returns the coarseness of the texture.
-    
+
     Step1  At each pixel, compute six averages for the windows of size 2**k x 2**k,
-            k=0,1,...,5, around the pixel. 
-    Step2  At each pixel, compute absolute differences E between the pairs of non 
+            k=0,1,...,5, around the pixel.
+    Step2  At each pixel, compute absolute differences E between the pairs of non
             overlapping averages in every directions.
-    step3  At each pixel, find the value of k that maximises the difference Ek in either 
+    step3  At each pixel, find the value of k that maximises the difference Ek in either
             direction and set the best size Sbest=2**k
     step4  Compute the coarseness feature Fcrs by averaging Sbest over the entire image.
 
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     voxelspacing : sequence of floats
         The side-length of each voxel.
     mask : array_like
         A binary mask for the image or a slice object
-        
+
     Returns
     -------
     coarseness : float
         The size of coarseness of the given texture. It is basically the size of
-        repeating elements in the image. 
-        
+        repeating elements in the image.
+
     See Also
     --------
-    
-    
+
+
     """
     # Step1:  At each pixel (x,y), compute six averages for the windows
     # of size 2**k x 2**k, k=0,1,...,5, around the pixel.
 
     image = numpy.asarray(image, dtype=numpy.float32)
-   
-  
+
+
     # set default mask or apply given mask
     if not type(mask) is slice:
         if not type(mask[0] is slice):
-            mask = numpy.array(mask, copy=False, dtype = numpy.bool)
+            mask = numpy.array(mask, copy=False, dtype = numpy.bool_)
     image = image[mask]
-    
+
     # set default voxel spacing if not suppliec
     if None == voxelspacing:
         voxelspacing = tuple([1.] * image.ndim)
-    
+
     if len(voxelspacing) != image.ndim:
         print("Voxel spacing and image dimensions do not fit.")
         return None
     # set padding for image border control
-    padSize = numpy.asarray([(numpy.rint((2**5.0) * voxelspacing[jj]),0) for jj in range(image.ndim)]).astype(numpy.int)
+    padSize = numpy.asarray([(numpy.rint((2**5.0) * voxelspacing[jj]),0) for jj in range(image.ndim)]).astype(int)
     Apad = numpy.pad(image,pad_width=padSize, mode='reflect')
 
     # Allocate memory
     E = numpy.empty((6,image.ndim)+image.shape)
 
-    # prepare some slicer 
+    # prepare some slicer
     rawSlicer           = [slice(None)] * image.ndim
     slicerForImageInPad = [slice(padSize[d][0],None)for d in range(image.ndim)]
 
@@ -97,18 +97,18 @@ def coarseness(image, voxelspacing = None, mask = slice(None)):
         size_vs = tuple(numpy.rint((2**k) * voxelspacing[jj]) for jj in range(image.ndim))
         A = uniform_filter(Apad, size = size_vs, mode = 'mirror')
 
-        # Step2: At each pixel, compute absolute differences E(x,y) between 
+        # Step2: At each pixel, compute absolute differences E(x,y) between
         # the pairs of non overlapping averages in the horizontal and vertical directions.
         for d in range(image.ndim):
             borders = numpy.rint((2**k) * voxelspacing[d])
-            
+
             slicerPad_k_d   = slicerForImageInPad[:]
             slicerPad_k_d[d]= slice((padSize[d][0]-borders if borders < padSize[d][0] else 0),None)
             A_k_d           = A[slicerPad_k_d]
 
             AslicerL        = rawSlicer[:]
             AslicerL[d]     = slice(0, -borders)
-            
+
             AslicerR        = rawSlicer[:]
             AslicerR[d]     = slice(borders, None)
 
@@ -116,10 +116,10 @@ def coarseness(image, voxelspacing = None, mask = slice(None)):
 
     # step3: At each pixel, find the value of k that maximises the difference Ek(x,y)
     # in either direction and set the best size Sbest(x,y)=2**k
-    
+
     k_max = E.max(1).argmax(0)
     dim = E.argmax(1)
-    dim_vox_space = numpy.asarray([voxelspacing[dim[k_max.flat[i]].flat[i]] for i in range(k_max.size)]).reshape(k_max.shape) 
+    dim_vox_space = numpy.asarray([voxelspacing[dim[k_max.flat[i]].flat[i]] for i in range(k_max.size)]).reshape(k_max.shape)
     S = (2**k_max) * dim_vox_space
 
     # step4: Compute the coarseness feature Fcrs by averaging Sbest(x,y) over the entire image.
@@ -128,51 +128,51 @@ def coarseness(image, voxelspacing = None, mask = slice(None)):
 def contrast(image, mask = slice(None)):
     r"""
     Takes a simple or multi-spectral image and returns the contrast of the texture.
-    
+
     Fcon = standard_deviation(gray_value) / (kurtosis(gray_value)**0.25)
-    
+
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     mask : array_like
         A binary mask for the image or a slice object
     Returns
     -------
     contrast : float
-        High differences in gray value distribution is represented in a high contrast value. 
-        
+        High differences in gray value distribution is represented in a high contrast value.
+
     See Also
     --------
-    
-    
+
+
     """
     image = numpy.asarray(image)
-    
+
     # set default mask or apply given mask
     if not type(mask) is slice:
         if not type(mask[0] is slice):
-            mask = numpy.array(mask, copy=False, dtype = numpy.bool)
+            mask = numpy.array(mask, copy=False, dtype = numpy.bool_)
     image = image[mask]
-    
+
     standard_deviation = numpy.std(image)
     kurtosis = stats.kurtosis(image, axis=None, bias=True, fisher=False)
-    n = 0.25 # The value n=0.25 is recommended as the best for discriminating the textures.  
-    
-    Fcon = standard_deviation / (kurtosis**n) 
-    
+    n = 0.25 # The value n=0.25 is recommended as the best for discriminating the textures.
+
+    Fcon = standard_deviation / (kurtosis**n)
+
     return Fcon
 
 def directionality(image, min_distance = 4, threshold = 0.1, voxelspacing = None, mask = slice(None)):
     r"""
     Takes a simple or multi-spectral image and returns the directionality of the image texture.
-    It is just a value representing the strength of directionality, not the specific direction. 
-    
+    It is just a value representing the strength of directionality, not the specific direction.
+
     An edge detection is applied on the image. Then the edge strength and directional angle between
     the image axis are computed. A histogram of the directional angles is than used to calculate a
     qualitative value for directionality in ONE image layer. Note that there are n choose 2 layers
-    in a n dimensional image. 
-    
+    in a n dimensional image.
+
     Warning
     -------
     Experimental. There are still issues with finding the right maxs and mins in histogram and
@@ -180,7 +180,7 @@ def directionality(image, min_distance = 4, threshold = 0.1, voxelspacing = None
 
     Parameters
     ----------
-    image : array_like or list/tuple of array_like 
+    image : array_like or list/tuple of array_like
         A single image or a list/tuple of images (for multi-spectral case).
     voxelspacing : sequence of floats
         The side-length of each voxel.
@@ -203,40 +203,40 @@ def directionality(image, min_distance = 4, threshold = 0.1, voxelspacing = None
         arctan(delta)| delta =    ---,---,---,---,---,  ---,---,---,---,---
                                     v   w   x   y   z     v   w   x   y   z
         There are always n choose k axis relations; n=image.ndim, k=2 (2 axis in every image layer).
-        
-    
+
+
     See Also
     --------
-    
+
     """
     image = numpy.asarray(image)
     ndim = image.ndim
     # set default mask or apply given mask
     if not type(mask) is slice:
         if not type(mask[0] is slice):
-            mask = numpy.array(mask, copy=False, dtype = numpy.bool)
+            mask = numpy.array(mask, copy=False, dtype = numpy.bool_)
     image = image[mask]
-           
+
     # set default voxel spacing if not suppliec
     if None == voxelspacing:
         voxelspacing = tuple([1.] * ndim)
-        
+
     if len(voxelspacing) != ndim:
         print("Voxel spacing and image dimensions do not fit.")
         return None
-   
-   # Calculate amount of combinations: n choose k, normalizing factor r and voxel spacing.    
+
+   # Calculate amount of combinations: n choose k, normalizing factor r and voxel spacing.
     n = (factorial(ndim)/(2*factorial(ndim-2)))
     pi1_2 = numpy.pi/2.0
     r=1.0 / (pi1_2**2)
     vs = [slice(None,None,numpy.rint(ii)) for ii in voxelspacing]
-   
+
     # Allocate memory, define constants
     Fdir = numpy.empty(n)
 
     # calculate differences by using Sobel-filter. (Maybe other filter kernel like Prewitt will do a better job)
     E = [sobel(image, axis=ndim-1-i) for i in range(ndim)]
-    
+
     # The edge strength e(x,y) is used for thresholding.
     e = sum(E) / float(ndim)
     border = [numpy.percentile(e, 1),numpy.percentile(e, 99)]
@@ -245,13 +245,13 @@ def directionality(image, min_distance = 4, threshold = 0.1, voxelspacing = None
     e -= border[0]
     e /= border[1]
     em = e > threshold
-        
+
     for i in range(n):
         A = numpy.arctan((E[(i + (ndim+i)/ndim) % ndim][vs]) / (E[i%ndim][vs]+numpy.spacing(1))) # [0 , pi/2]
         A = A[em[vs]]
-        # Calculate number of bins for the histogram. Watch out, this is just a work around! 
+        # Calculate number of bins for the histogram. Watch out, this is just a work around!
         # @TODO: Write a more stable code to prevent for minimum and maximum repetition when the same value in the Histogram appears multiple times in a row. Example: image = numpy.zeros([10,10]), image[:,::3] = 1
-        bins = numpy.unique(A).size + min_distance        
+        bins = numpy.unique(A).size + min_distance
         H = numpy.histogram(A, bins = bins, density=True)[0] # [0 , 1]
         H[H < numpy.percentile(H,1)] = 0.0
         H_peaks, H_valleys, H_range = find_valley_range(H)
@@ -260,8 +260,8 @@ def directionality(image, min_distance = 4, threshold = 0.1, voxelspacing = None
             for range_idx in range( H_valleys[idx_ap], H_valleys[idx_ap]+H_range[idx_ap]):
                 a=range_idx % len(H)
                 summe += (((pi1_2*a)/bins - (pi1_2 * H_peaks[idx_ap])/bins) **2) * H[a]
-        Fdir[i] = 1.0 - r * summe 
-        
+        Fdir[i] = 1.0 - r * summe
+
     return Fdir
 
 
@@ -299,7 +299,7 @@ def find_valley_range(vector, min_distance = 4):
     Returns UNSORTED indices of maxima in input vector.
     Returns range of valleys before and after maximum
     """
-    
+
     # http://users.monash.edu.au/~dengs/resource/papers/icme08.pdf
     # find min and max with mode = wrap
     mode = "wrap"
@@ -311,14 +311,14 @@ def find_valley_range(vector, min_distance = 4):
             maxima=maxima[1:]
         else:
             maxima=maxima[:-1]
-        
+
     if len(maxima)==len(minima):
         valley_range = numpy.asarray([minima[ii+1] - minima[ii] for ii in range(len(minima)-1)] + [len(vector)-minima[-1]+minima[0]])
         if minima[0] < maxima[0]:
             minima = numpy.asarray(list(minima) + [minima[0]])
         else:
-            minima = numpy.asarray(list(minima) + [minima[-1]])       
+            minima = numpy.asarray(list(minima) + [minima[-1]])
     else:
         valley_range = numpy.asarray([minima[ii+1] - minima[ii] for ii in range(len(maxima))])
-    
+
     return maxima, minima, valley_range

--- a/medpy/features/utilities.py
+++ b/medpy/features/utilities.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -32,34 +32,34 @@ def normalize(vector, cutoffp = (0, 100), model = False):
     r"""
     Returns a feature-wise normalized version of the supplied vector. Normalization is
     achieved to [0,1] over the complete vector using shifting and scaling.
-    
+
     When cut-off percentile (cutoffp) values other than (0, 100) are supplied, the values
     lying before or behind the supplied percentiles are cut-off i.e. shifted to fit the
-    range. 
-    
+    range.
+
     When model is set to True, an additional model describing the normalization is
     returned, that can at a later point be passed to the `normalize_with_model` function
     to normalize other feature vectors accordingly to the one passed.
-    
+
     The vector is expected to have the form samples*features i.e.::
-    
+
             s1    s2    s3    [...]
         f1
         f2
         [...]
-    
+
     Therefore a supplied vector::
-    
+
             s1    s2    s3
         f1   1.5    1    2
         f2    -1    0    1
-    
+
     would result in the returned vector::
-    
+
             s1    s2    s3
         f1 0.50  0.00  1.00
         f2 0.00  0.50  1.00
-    
+
     Parameters
     ----------
     vector : sequence
@@ -68,98 +68,98 @@ def normalize(vector, cutoffp = (0, 100), model = False):
         Cut-off percentiles.
     model : bool
         Whether to return the learned normalization model.
-    
+
     Returns
     -------
     normalized_feature_vectors : ndarray
         The normalized versions of the input vectors.
     model : tuple, optional
         The learned normalization model.
-    
+
     """
-    vector = numpy.array(vector, dtype=numpy.float)
-    
+    vector = numpy.array(vector, dtype=float)
+
     # add a singleton dimension if required
     if 1 == vector.ndim:
         vector = vector[:, None]
-    
+
     # compute lower and upper range border of each row using the supplied percentiles
     minp, maxp = numpy.percentile(vector, cutoffp, 0)
-    
+
     # shift outliers to fit range
     for i in range(vector.shape[1]):
         vector[:,i][vector[:,i] < minp[i]] = minp[i]
         vector[:,i][vector[:,i] > maxp[i]] = maxp[i]
-    
+
     # normalize
     minv = vector.min(0)
     vector -= minv
     maxv = vector.max(0)
     vector /= maxv
-    
+
     if not model:
         return vector
     else:
         return vector, (minp, maxp, minv, maxv)
-    
+
 def normalize_with_model(vector, model):
     r"""
     Normalize as with `normalize`, but not based on the data of the passed feature
     vector, but rather on a learned model created with `normalize`. Thus formerly
     unseen query data can be normalized according to the training data.
-    
+
     Parameters
     ----------
     vector : sequence
         A sequence of feature vectors to normalize.
     model : tuple
         A normalization model created with `normalize`.
-    
+
     Returns
     -------
     normalize : ndarray
         The normalized versions of the input vectors.
     """
-    vector = numpy.array(vector, dtype=numpy.float)
-    
+    vector = numpy.array(vector, dtype=float)
+
     # unpack model
     minp, maxp, minv, maxv = model
-    
+
     # add a singleton dimension if required
     if 1 == vector.ndim:
         vector = vector[:, None]
-    
+
     # shift outliers to fit range
     for i in range(vector.shape[1]):
         vector[:,i][vector[:,i] < minp[i]] = minp[i]
         vector[:,i][vector[:,i] > maxp[i]] = maxp[i]
-        
+
     # normalize
     vector -= minv
     vector /= maxv
-    
-    return vector        
+
+    return vector
 
 def append(*vectors):
     r"""
     Takes an arbitrary number of vectors containing features and append them
     (horizontally).
-    
+
     E.g. taking a 100 and a 200 sample vector with 7 features each, a 300x7
     vector is returned.
-    
+
     The vectors are expected to have the form samples*features i.e.::
-    
+
             s1    s2    s3    [...]
         f1
         f2
         [...]
-    
+
     Parameters
     ----------
     *vectors : sequences
         A number of vectors with the same number and type of features.
-    
+
     Returns
     -------
     vector : ndarray
@@ -168,7 +168,7 @@ def append(*vectors):
     # check supplied arguments
     if len(vectors) < 2:
         return vectors[0]
-    
+
     # process supplied arguments
     vectors = list(vectors)
     for i in range(len(vectors)):
@@ -177,27 +177,27 @@ def append(*vectors):
             vectors[i] = numpy.asarray([vectors[i]]).T
 
     return numpy.squeeze(numpy.concatenate(vectors, 0))
-    
+
 def join(*vectors):
     r"""
     Takes an arbitrary number of aligned vectors of the same length and combines
     them into a single vector (vertically).
-    
+
     E.g. taking two 100-sample feature vectors of once 5 and once 7 features, a 100x12
-    feature vector is created and returned. 
-    
+    feature vector is created and returned.
+
     The feature vectors are expected to have the form samples*features i.e.::
-    
+
             s1    s2    s3    [...]
         f1
         f2
         [...]
-    
+
     Parameters
     ----------
     *vectors : sequences
         A number of vectors with the same number of samples.
-    
+
     Returns
     -------
     vector : ndarray
@@ -213,9 +213,9 @@ def join(*vectors):
         vectors[i] = numpy.array(vectors[i], copy=False)
         if vectors[i].ndim == 1:
             vectors[i] = numpy.array([vectors[i]], copy=False).T
-    
+
     # treat single-value cases special (no squeezing)
     if 1 == len(vectors[0]):
         return numpy.concatenate(vectors, 1)
-    
+
     return numpy.squeeze(numpy.concatenate(vectors, 1))

--- a/medpy/filter/IntensityRangeStandardization.py
+++ b/medpy/filter/IntensityRangeStandardization.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -32,55 +32,55 @@ from scipy.interpolate.interpolate import interp1d
 class IntensityRangeStandardization (object):
     r"""
     Class to standardize intensity ranges between a number of images.
-    
+
     **Short description:**
     Often images containing similar objects or scenes have different intensity ranges
     that make it difficult to compare them manually as well as to process them
     further.
-    
+
     IntensityRangeStandardization offers a way to transform a number of such images
     intensity ranges to a common standard intensity space without any loss of
     information using a multi-segment linear transformation model.
-    
+
     Once learned, this model can be applied to other, formerly unseen images to map
-    them to the same standard intensity space.    
-            
+    them to the same standard intensity space.
+
     **Concept of similar images:**
     IntensityRangeStandardization is limited to similar images. Images containing
     different object or different compositions of objects are not suitable to be
     transformed to a common intensity space (and it would furthermore not make much
     sense).
-    
+
     A typical application of IntensityRangeStandardization are MRI images showing the
     same body region. These often have different intensity ranges, even when acquired
     from the same patient and using the same scanner. For further processing, e.g.
     for training a classifier, they have to be mapped to a common intensity space.
-    
+
     **Failure of the transformation:**
     The method implemented in IntensityRangeStandardization ensures that no
     information is lost i.e. a lossless transformation is performed. This can be
     assured when there exists a one-to-one mapping between the images original
     intensity values and their values mapped to the standard intensity space.
-    
+
     But since the transformation model is trained on, and the standard intensity
     space range selected over the training images, this can not be guaranteed for all
     formerly unseen image. If they differ greatly from the training set images, a
     lossless transformation can not be assured anymore. In this case the transform()
     method will throw an InformationLossException.
-    
+
     Should this happen, the model needs to be re-trained with the original training
     images and additionally the images which caused the failure. Since this will lead
     to a new intensity standard space, all already transformed images have to be
     processed again.
-    
+
     **Setting the training parameters:**
     The method comes with a set of default parameters, that are suitable for most
     cases. But for some special cases, it might be better to set them on your own. Ti
     understand the working of the parameters, it is recommended to read the detailed
     method description first.
-    
+
     **The method depends on three parameters:**
-    
+
     cutoffp, i.e. the cut-off percentiles
         These are used to the define the intensity outliers, both during training and
         image transformation. The default values are usualy a good choice.
@@ -97,14 +97,14 @@ class IntensityRangeStandardization (object):
         is usually recommended to let the method select it automatically during the
         training process. It is additionally possible to supply only the lower or
         upper range border and set the other to ''auto'', in which case the method
-        chooses the range automatically, but not the position. 
+        chooses the range automatically, but not the position.
         (in [1]_ these are called the minimum and maximum intensities on the standard scale of the IOI s1 resp. s2)
-    
-    
+
+
     **Details of the method:**
     In the following the method is described in some more detail. For even more
     information see [1]_.
-         
+
     Essentially the method is based on a multi-segment linear transformation model. A
     standard intensity space (or common intensity space) is defined by an intensity
     value range ''stdrange''.
@@ -114,7 +114,7 @@ class IntensityRangeStandardization (object):
     at a number of landmark percentiles are extracted and passed to the linear
     mapping to be transfered roughly to the standard intensity space. The mean of all
     these mapped landmark intensities form the model learned.
-      
+
     When presented with an image to transform, these images intensity values are
     extracted at the cut-off percentile as well as at the landmark percentile
     positions. This results in a number of segments. Using these and the
@@ -122,13 +122,13 @@ class IntensityRangeStandardization (object):
     values, a multi-segment linear transformation model is created for the image.
     This is then applied to the images intensity values to map them to the standard
     intensity space.
-    
+
     Outliers, i.e. the images intensity values that lie outside of the cut-off
     percentiles, are treated separately. They are transformed like the first resp.
     last segmented of the transformation model. Not that this means the transformed
     images intensity values do not always lie inside the standard intensity space
     range, but are fitted as best as possible inside.
-         
+
     Parameters
     ----------
     cutoffp : (float, float)
@@ -142,43 +142,43 @@ class IntensityRangeStandardization (object):
         determined from the training image upon training; it is also
         possible to fix either the upper or the lower border value and
         setting the other to 'auto'.
-        
+
     Examples
     --------
     We have a number of similar images with varying intensity ranges. To make them
     comparable, we would like to transform them to a common intensity space. Thus we
     run:
-    
+
         >>> from medpy.filter import IntensityRangeStandardization
         >>> irs = IntensityRangeStandardization()
         >>> trained_model, transformed_images = irs.train_transform(images)
-        
+
     Let us assume we now obtain another, new image, that we would like to make
     comparable to the others. As long as it does not differ to much from these, we
     can simply call:
-        
+
         >>> transformed_image = irs.transform(new_image)
-        
+
     For many application, not all images are already available at the time of
     execution. It would therefore be good to be able to preserve a once trained
     model. The solution is to just pickle the once trained model:
-    
+
         >>> import pickle
         >>> with open('my_trained_model.pkl', 'wb') as f:
         >>>     pickle.dump(irs, f)
-            
+
     And load it again when required with:
-    
+
         >>> with open('my_trained_model.pkl', 'r') as f:
         >>>     irs = pickle.load(f)
-        
+
     References
     ----------
     .. [1] Nyul, L.G.; Udupa, J.K.; Xuan Zhang, "New variants of a method of MRI scale
        standardization," Medical Imaging, IEEE Transactions on , vol.19, no.2, pp.143-150,
        Feb. 2000
-    """    
-    
+    """
+
     # static member variables
     L2 = [50]
     """1-value landmark points model."""
@@ -186,7 +186,7 @@ class IntensityRangeStandardization (object):
     """3-value landmark points model."""
     L4 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
     """9-value landmark points model."""
-    
+
     def __init__(self, cutoffp = (1, 99), landmarkp = L4, stdrange = 'auto'):
         # check parameters
         if not IntensityRangeStandardization.is_sequence(cutoffp):
@@ -199,7 +199,7 @@ class IntensityRangeStandardization (object):
             raise ValueError('cutoffp elements must be in [0, 100]')
         if not cutoffp[1] > cutoffp[0]:
             raise ValueError('the second element of cutoffp must be larger than the first')
-        
+
         if not IntensityRangeStandardization.is_sequence(landmarkp):
             raise ValueError('landmarkp must be a sequence')
         if not 1 <= len(landmarkp):
@@ -212,7 +212,7 @@ class IntensityRangeStandardization (object):
             raise ValueError('landmarkp elements must be in between the elements of cutoffp')
         if not len(landmarkp) == len(numpy.unique(landmarkp)):
             raise ValueError('landmarkp elements must be unique')
-        
+
         if 'auto' == stdrange:
             stdrange = ('auto', 'auto')
         else:
@@ -229,36 +229,36 @@ class IntensityRangeStandardization (object):
                 raise ValueError('stdrange elements must be numbers or \'auto\'')
             elif 'auto' == stdrange[1] and not IntensityRangeStandardization.is_number(stdrange[0]):
                 raise ValueError('stdrange elements must be numbers or \'auto\'')
-                
-        
+
+
         # process parameters
         self.__cutoffp = IntensityRangeStandardization.to_float(cutoffp)
         self.__landmarkp = IntensityRangeStandardization.to_float(sorted(landmarkp))
         self.__stdrange = ['auto' if 'auto' == x else float(x) for x in stdrange]
-            
+
         # initialize remaining instance parameters
         self.__model = None
         self.__sc_umins = None
         self.__sc_umaxs = None
-        
+
     def train(self, images):
         r"""
         Train a standard intensity space and an associated transformation model.
-        
+
         Note that the passed images should be masked to contain only the foreground.
-        
+
         Parameters
         ----------
         images : sequence of array_likes
             A number of images.
-        
+
         Returns
         -------
         IntensityRangeStandardization : IntensityRangeStandardization
             This instance of IntensityRangeStandardization
         """
         self.__stdrange = self.__compute_stdrange(images)
-        
+
         lim = []
         for idx, i in enumerate(images):
             ci = numpy.array(numpy.percentile(i, self.__cutoffp))
@@ -266,76 +266,76 @@ class IntensityRangeStandardization (object):
             ipf = interp1d(ci, self.__stdrange)
             lim.append(ipf(li))
 
-            # treat single intensity accumulation error            
+            # treat single intensity accumulation error
             if not len(numpy.unique(numpy.concatenate((ci, li)))) == len(ci) + len(li):
                 raise SingleIntensityAccumulationError('Image no.{} shows an unusual single-intensity accumulation that leads to a situation where two percentile values are equal. This situation is usually caused, when the background has not been removed from the image. Another possibility would be to reduce the number of landmark percentiles landmarkp or to change their distribution.'.format(idx))
-            
+
         self.__model = [self.__stdrange[0]] + list(numpy.mean(lim, 0)) + [self.__stdrange[1]]
         self.__sc_umins = [self.__stdrange[0]] + list(numpy.min(lim, 0)) + [self.__stdrange[1]]
         self.__sc_umaxs = [self.__stdrange[0]] + list(numpy.max(lim, 0)) + [self.__stdrange[1]]
-            
+
         return self
-        
+
     def transform(self, image, surpress_mapping_check = False):
         r"""
         Transform an images intensity values to the learned standard intensity space.
-        
+
         Note that the passed image should be masked to contain only the foreground.
-        
+
         The transformation is guaranteed to be lossless i.e. a one-to-one mapping between
         old and new intensity values exists. In cases where this does not hold, an error
         is thrown. This can be suppressed by setting ``surpress_mapping_check`` to 'True'.
         Do this only if you know what you are doing.
-        
+
         Parameters
         ----------
         image : array_like
             The image to transform.
         surpress_mapping_check : bool
             Whether to ensure a lossless transformation or not.
-        
+
         Returns
         -------
         image : ndarray
             The transformed image
-        
+
         Raises
         -------
-        InformationLossException 
+        InformationLossException
             If a lossless transformation can not be ensured
         Exception
             If no model has been trained before
         """
         if None == self.__model:
             raise UntrainedException('Model not trained. Call train() first.')
-        
+
         image = numpy.asarray(image)
-        
+
         # determine image intensity values at cut-off percentiles & landmark percentiles
         li = numpy.percentile(image, [self.__cutoffp[0]] + self.__landmarkp + [self.__cutoffp[1]])
-        
-        # treat single intensity accumulation error            
+
+        # treat single intensity accumulation error
         if not len(numpy.unique(li)) == len(li):
             raise SingleIntensityAccumulationError('The image shows an unusual single-intensity accumulation that leads to a situation where two percentile values are equal. This situation is usually caused, when the background has not been removed from the image. The only other possibility would be to re-train the model with a reduced number of landmark percentiles landmarkp or a changed distribution.')
-        
-        # create linear mapping models for the percentile segments to the learned standard intensity space  
+
+        # create linear mapping models for the percentile segments to the learned standard intensity space
         ipf = interp1d(li, self.__model, bounds_error = False)
-        
+
         # transform the input image intensity values
         output = ipf(image)
-        
+
         # treat image intensity values outside of the cut-off percentiles range separately
         llm = IntensityRangeStandardization.linear_model(li[:2], self.__model[:2])
         rlm = IntensityRangeStandardization.linear_model(li[-2:], self.__model[-2:])
-        
+
         output[image < li[0]] = llm(image[image < li[0]])
         output[image > li[-1]] = rlm(image[image > li[-1]])
-        
+
         if not surpress_mapping_check and not self.__check_mapping(li):
             raise InformationLossException('Image can not be transformed to the learned standard intensity space without loss of information. Please re-train.')
-        
+
         return output
-    
+
     def train_transform(self, images, surpress_mapping_check = False):
         r"""
         See also
@@ -345,73 +345,73 @@ class IntensityRangeStandardization (object):
         ret = self.train(images)
         outputs = [self.transform(i, surpress_mapping_check) for i in images]
         return ret, outputs
-    
+
     @property
     def stdrange(self):
         """Get the set resp. learned standard intensity range."""
         return self.__stdrange
-    
+
     @property
     def cutoffp(self):
         """Get the cut-off percentiles."""
         return self.__cutoffp
-    
+
     @property
     def landmarkp(self):
         """Get the landmark percentiles."""
         return self.__landmarkp
-    
+
     @property
     def model(self):
         """Get the model (the learned percentile values)."""
         return self.__model
-    
+
     def __compute_stdrange(self, images):
         r"""
         Computes a common standard intensity range over a number of images.
-        
+
         Depending on the settings of the internal self.__stdrange variable,
         either (1) the already fixed values are returned, (2) a complete standard
         intensity range is computed from the supplied images, (3) an intensity range
         fixed at the lower end or (4) an intensity range fixed at the upper end is
         returned.
-        
+
         Takes into account the maximum length of each percentile segment over all
         images, then adds a security margin defined by the highest variability among
         all segments over all images.
-        
+
         Be
-        
+
         .. math::
-        
+
             L = (cop_l, lp_1, lp_2, ..., lp_n, cop_u)
-        
+
         the set formed by the two cut-off percentiles :math:`cop_l` and :math:`cop_u` and the
         landmark percentiles :math:`lp_1, ..., lp_n`. The corresponding intensity values of
         an image :math:`i\in I` are then
-        
+
         .. math::
-            
+
             V_i = (v_{i,1}, v_{i,2}, ..., v_{i,n+2})
-        
+
         The distance between each of these intensity values forms a segment along the
         images :math:`i` intensity range denoted as
-        
+
         ..math ::
-            
+
             S_i = (s_{i,1}, s_{i,2}, ..., s_{i, n+1})
-        
+
         The common standard intensity range :math:`sir` over the set of images :math:`I` is
         then defined as
-        
+
         ..math ::
             sir = \sum_{l=1}^{n+1}\max_{i=1}^I s_{i,l} * \max_{l=1}^{n+1} \left(\frac{\max_{i=1}^I s_{i,l}}{\min_{i=1}^I s_{i,l}}\right)
-        
+
         Parameters
         ----------
         images : sequence of array_like
             A number of images.
-            
+
         Returns
         -------
         stdrange : (float, float)
@@ -419,35 +419,35 @@ class IntensityRangeStandardization (object):
         """
         if not 'auto' in self.__stdrange:
             return self.__stdrange
-        
+
         copl, copu = self.__cutoffp
-        
-        # collect cutoff + landmark percentile segments and image mean intensity values 
+
+        # collect cutoff + landmark percentile segments and image mean intensity values
         s = []
         m = []
         for idx, i in enumerate(images):
             li = numpy.percentile(i, [copl] + self.__landmarkp + [copu])
-            
+
             s.append(numpy.asarray(li)[1:] - numpy.asarray(li)[:-1])
             m.append(i.mean())
-            
+
             # treat single intensity accumulation error
             if 0 in s[-1]:
                 raise SingleIntensityAccumulationError('Image no.{} shows an unusual single-intensity accumulation that leads to a situation where two percentile values are equal. This situation is usually caused, when the background has not been removed from the image. Another possibility would be to reduce the number of landmark percentiles landmarkp or to change their distribution.'.format(idx))
-            
+
         # select the maximum and minimum of each percentile segment over all images
         maxs = numpy.max(s, 0)
         mins = numpy.min(s, 0)
-        
+
         # divide them pairwise
-        divs = numpy.divide(numpy.asarray(maxs, dtype=numpy.float), mins) 
-        
+        divs = numpy.divide(numpy.asarray(maxs, dtype=float), mins)
+
         # compute interval range according to generalized theorem 2 of [1]
         intv = numpy.sum(maxs) + numpy.max(divs)
-        
+
         # compute mean intensity value over all images (assuming equal size)
         im = numpy.mean(m)
-        
+
         # return interval with borders according to settings
         if 'auto' == self.__stdrange[0] and 'auto' == self.__stdrange[1]:
             return im - intv / 2, im + intv / 2
@@ -455,7 +455,7 @@ class IntensityRangeStandardization (object):
             return self.__stdrange[1] - intv, self.__stdrange[1]
         else:
             return self.__stdrange[0], self.__stdrange[0] + intv
-        
+
     def __check_mapping(self, landmarks):
         """
         Checks whether the image, from which the supplied landmarks were extracted, can
@@ -465,19 +465,19 @@ class IntensityRangeStandardization (object):
         sc_udiff = numpy.asarray(self.__sc_umaxs)[1:] - numpy.asarray(self.__sc_umins)[:-1]
         l_diff = numpy.asarray(landmarks)[1:] - numpy.asarray(landmarks)[:-1]
         return numpy.all(sc_udiff > numpy.asarray(l_diff))
-        
+
     @staticmethod
     def is_sequence(arg):
         """
         Checks via its hidden attribute whether the passed argument is a sequence (but
         excluding strings).
-        
+
         Credits to Steve R. Hastings a.k.a steveha @ http://stackoverflow.com
         """
         return (not hasattr(arg, "strip") and
             hasattr(arg, "__getitem__") or
             hasattr(arg, "__iter__"))
-        
+
     @staticmethod
     def is_number(arg):
         """
@@ -485,14 +485,14 @@ class IntensityRangeStandardization (object):
         """
         import numbers
         return isinstance(arg, numbers.Number)
-    
+
     @staticmethod
     def are_numbers(arg):
         """
         Checks whether all elements in a sequence are valid numbers.
         """
         return numpy.all([IntensityRangeStandardization.is_number(x) for x in arg])
-    
+
     @staticmethod
     def is_in_interval(n, l, r, border = 'included'):
         """
@@ -504,7 +504,7 @@ class IntensityRangeStandardization (object):
             return (n > l) and (n < r)
         else:
             raise ValueError('borders must be either \'included\' or \'excluded\'')
-        
+
     @staticmethod
     def are_in_interval(s, l, r, border = 'included'):
         """
@@ -512,14 +512,14 @@ class IntensityRangeStandardization (object):
         l and r.
         """
         return numpy.all([IntensityRangeStandardization.is_in_interval(x, l, r, border) for x in s])
-    
+
     @staticmethod
     def to_float(s):
         """
         Cast a sequences elements to float numbers.
         """
         return [float(x) for x in s]
-    
+
     @staticmethod
     def linear_model(x, y):
         """
@@ -532,19 +532,19 @@ class IntensityRangeStandardization (object):
         m = (y2 - y1) / (x2 - x1)
         b = y1 - (m * x1)
         return lambda x: m * x + b
-    
+
 class SingleIntensityAccumulationError(Exception):
     """
     Thrown when an image shows an unusual single-intensity peaks which would obstruct
     both, training and transformation.
     """
-    
+
 class InformationLossException(Exception):
     """
     Thrown when a transformation can not be guaranteed to be lossless.
     """
     pass
-    
+
 class UntrainedException(Exception):
     """
     Thrown when a transformation is attempted before training.

--- a/medpy/filter/binary.py
+++ b/medpy/filter/binary.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -22,7 +22,7 @@
 from operator import  lt, le, gt, ge, ne, eq
 
 # third-party modules
-import numpy 
+import numpy
 from scipy.ndimage import label
 
 # own modules
@@ -31,18 +31,18 @@ from scipy.ndimage import label
 def size_threshold(img, thr, comp='lt', structure = None):
     r"""
     Removes binary objects from an image identified by a size threshold.
-    
+
     The unconnected binary objects in an image are identified and all removed
     whose size compares (e.g. less-than) to a supplied threshold value.
-    
+
     The threshold ``thr`` can be any positive integer value. The comparison operator
     can be one of lt, le, gt, ge, ne or eq. The operators used are the functions of
     the same name supplied by the `operator` module of python.
-    
+
     Parameters
     ----------
     img : array_like
-        An array containing connected objects. Will be cast to type numpy.bool.
+        An array containing connected objects. Will be cast to type numpy.bool_.
     thr : int
         Integer defining the threshold size of the binary objects to remove.
     comp : {'lt', 'le', 'gt', 'ge', 'ne', 'eq'}
@@ -53,77 +53,77 @@ def size_threshold(img, thr, comp='lt', structure = None):
         one is automatically generated with a squared connectivity equal to
         one. That is, for a 2-D ``input`` array, the default structuring element
         is::
-        
+
             [[0,1,0],
              [1,1,1],
              [0,1,0]]
-    
+
     Returns
     -------
     binary_image : ndarray
         The supplied binary image with all objects removed that positively compare
         to the threshold ``thr`` using the comparison operator defined with ``comp``.
-        
+
     Notes
     -----
     If your voxel size is no isotrop i.e. of side-length 1 for all dimensions, simply
     divide the supplied threshold through the real voxel size.
     """
-    
+
     operators = {'lt': lt, 'le': le, 'gt': gt, 'ge': ge, 'eq': eq, 'ne': ne}
-    
-    img = numpy.asarray(img).astype(numpy.bool)
+
+    img = numpy.asarray(img).astype(numpy.bool_)
     if comp not in operators:
         raise ValueError("comp must be one of {}".format(list(operators.keys())))
     comp = operators[comp]
-    
+
     labeled_array, num_features = label(img, structure)
     for oidx in range(1, num_features + 1):
         omask = labeled_array == oidx
         if comp(numpy.count_nonzero(omask), thr):
             img[omask] = False
-            
+
     return img
 
 def largest_connected_component(img, structure = None):
     r"""
     Select the largest connected binary component in an image.
-    
+
     Treats all zero values in the input image as background and all others as foreground.
     The return value is an binary array of equal dimensions as the input array with TRUE
     values where the largest connected component is situated.
-    
+
     Parameters
     ----------
     img : array_like
-        An array containing connected objects. Will be cast to type numpy.bool.
+        An array containing connected objects. Will be cast to type numpy.bool_.
     structure : array_like
         A structuring element that defines the connectivity. Structure must be symmetric.
         If no structuring element is provided, one is automatically generated with a
         squared connectivity equal to one.
-    
+
     Returns
     -------
     binary_image : ndarray
         The supplied binary image with only the largest connected component remaining.
-    """   
+    """
     labeled_array, num_features = label(img, structure)
     component_sizes = [numpy.count_nonzero(labeled_array == label_idx) for label_idx in range(1, num_features + 1)]
     largest_component_idx = numpy.argmax(component_sizes) + 1
 
-    out = numpy.zeros(img.shape, numpy.bool)  
+    out = numpy.zeros(img.shape, numpy.bool_)
     out[labeled_array == largest_component_idx] = True
     return out
 
 def bounding_box(img):
     r"""
     Return the bounding box incorporating all non-zero values in the image.
-    
+
     Parameters
     ----------
     img : array_like
         An array containing non-zero objects.
-        
+
     Returns
     -------
     bbox : a list of slicer objects defining the bounding box

--- a/medpy/filter/houghtransform.py
+++ b/medpy/filter/houghtransform.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -32,12 +32,12 @@ def ght_alternative (img, template, indices):
     """
     Alternative implementation of the general hough transform, which uses iteration over
     indices rather than broadcasting rules like `ght`.
-    
+
     It is therefore considerably slower, especially for large, multi-dimensional arrays.
     The only application are cases, where the hough transform should only be computed for
     a small number of points (=template centers) in the image. In this case the indices
     of interest can be provided as a list.
-    
+
     Parameters
     ----------
     img : array_like
@@ -46,7 +46,7 @@ def ght_alternative (img, template, indices):
         A boolean array containing the structure to search for.
     indices : sequences
         A sequence of image indices at which to compute the hough transform.
-    
+
     Returns
     -------
     hough_transform : ndarray
@@ -54,87 +54,87 @@ def ght_alternative (img, template, indices):
     """
     # cast template to bool and img to numpy array
     img = numpy.asarray(img)
-    template = numpy.asarray(template).astype(numpy.bool)
-    
+    template = numpy.asarray(template).astype(numpy.bool_)
+
     # check supplied parameters
     if img.ndim != template.ndim:
         raise AttributeError('The supplied image and template must be of the same dimensionality.')
     if not numpy.all(numpy.greater_equal(img.shape, template.shape)):
         raise AttributeError('The supplied template is bigger than the image. This setting makes no sense for a hough transform.')
-    
+
     # pad the original image
     img_padded = pad(img, footprint=template, mode='constant')
-    
+
     # prepare the hough image
-    if numpy.bool == img.dtype:
+    if numpy.bool_ == img.dtype:
         img_hough = numpy.zeros(img.shape, numpy.int32)
     else:
         img_hough = numpy.zeros(img.shape, img.dtype)
-        
+
     # iterate over the pixels, apply the template center to each of these and save the sum into the hough image
     for idx_hough in indices:
         idx_hough = tuple(idx_hough)
         slices_img_padded = [slice(idx_hough[i], None) for i in range(img_hough.ndim)]
-        img_hough[idx_hough] = sum(img_padded[slices_img_padded][template])     
-        
+        img_hough[idx_hough] = sum(img_padded[slices_img_padded][template])
+
     return img_hough
 
 def ght(img, template):
     r"""
     Implementation of the general hough transform for all dimensions.
-    
+
     Providing a template, this method searches in the image for structures similar to the
     one depicted by the template. The returned hough image denotes how well the structure
     fit in each index.
-    
+
     The indices of the returned image correspond with the centers of the template. At the
     corresponding locations of the original image the template is applied (like a stamp)
     and the underlying voxel values summed up to form the hough images value. It is
     suggested to normalize the input image before for speaking results.
-    
+
     This function behaves as the general hough transform if a binary image has been
     supplied. In the case of a gray-scale image, the values of the pixels under the
     templates structure are summed up, thus weighting becomes possible.
-    
+
     Parameters
     ----------
     img : array_like
         The image in which to search for the structure.
     template : array_like
         A boolean array containing the structure to search for.
-    
+
     Returns
     -------
     hough_transform : ndarray
         The general hough transformation image.
-        
+
     Notes
     -----
     The center of a structure with odd side-length is simple the arrays middle. When an
     even-sided array has been supplied as template, the middle rounded down is taken as
     the structures center. This means that in the second case the hough image is shifted
     by half a voxel (:math:`ndim * [-0.5]`).
-    """    
+    """
     # cast template to bool and img to numpy array
     img = numpy.asarray(img)
-    template = numpy.asarray(template).astype(numpy.bool)
-    
+    template = numpy.asarray(template).astype(numpy.bool_)
+
     # check supplied parameters
     if img.ndim != template.ndim:
         raise AttributeError('The supplied image and template must be of the same dimensionality.')
     if not numpy.all(numpy.greater_equal(img.shape, template.shape)):
-        raise AttributeError('The supplied template is bigger than the image. This setting makes no sense for a hough transform.')    
-    
+        raise AttributeError('The supplied template is bigger than the image. This setting makes no sense for a hough transform.')
+
     # compute center of template array
     center = (numpy.asarray(template.shape) - 1) // 2
-    
+
     # prepare the hough image
-    if numpy.bool == img.dtype:
+    if numpy.bool_ == img.dtype:
         img_hough = numpy.zeros(img.shape, numpy.int32)
     else:
         img_hough = numpy.zeros(img.shape, img.dtype)
-    
-    # iterate over the templates non-zero positions and sum up the images accordingly shifted 
+
+    # iterate over the templates non-zero positions and sum up the images accordingly shifted
     for idx in numpy.transpose(template.nonzero()):
         slicers_hough = []
         slicers_orig = []
@@ -150,7 +150,7 @@ def ght(img, template):
                 slicers_hough.append(slice(None, pos))
                 slicers_orig.append(slice(-1 * pos, None))
         img_hough[slicers_hough] += img[slicers_orig]
-        
+
     return img_hough
 
 def template_sphere (radius, dimensions):
@@ -173,7 +173,7 @@ def template_sphere (radius, dimensions):
     if int(dimensions) != dimensions:
         raise TypeError('The supplied dimension parameter must be of type integer.')
     dimensions = int(dimensions)
-    
+
     return template_ellipsoid(dimensions * [radius * 2])
 
 
@@ -181,25 +181,25 @@ def template_ellipsoid(shape):
     r"""
     Returns an ellipsoid binary structure of a of the supplied radius that can be used as
     template input to the generalized hough transform.
-    
+
     Parameters
     ----------
     shape : tuple of integers
         The main axes of the ellipsoid in voxel units.
-    
+
     Returns
     -------
     template_sphere : ndarray
         A boolean array containing an ellipsoid.
     """
     # prepare template array
-    template = numpy.zeros([int(x // 2 + (x % 2)) for x in shape], dtype=numpy.bool) # in odd shape cases, this will include the ellipses middle line, otherwise not
+    template = numpy.zeros([int(x // 2 + (x % 2)) for x in shape], dtype=numpy.bool_) # in odd shape cases, this will include the ellipses middle line, otherwise not
 
     # get real world offset to compute the ellipsoid membership
     rw_offset = []
     for s in shape:
-        if int(s) % 2 == 0: rw_offset.append(0.5 - (s % 2) / 2.) # number before point is even 
-        else: rw_offset.append(-1 * (s % int(s)) / 2.) # number before point is odd 
+        if int(s) % 2 == 0: rw_offset.append(0.5 - (s % 2) / 2.) # number before point is even
+        else: rw_offset.append(-1 * (s % int(s)) / 2.) # number before point is odd
 
     # prepare an array containing the squares of the half axes to avoid computing inside the loop
     shape_pow = numpy.power(numpy.asarray(shape) / 2., 2)
@@ -212,7 +212,7 @@ def template_ellipsoid(shape):
     for idx in numpy.ndindex(template.shape):
         distance = sum((math.pow(coordinate + rwo, 2) / axes_pow for axes_pow, coordinate, rwo in zip(shape_pow, idx, rw_offset))) # plus once since ndarray is zero based, but real-world coordinates not
         if distance <= 1: template[idx] = True
-        
+
     # we take now our ellipse part and flip it once along each dimension, concatenating it in each step
     # the slicers are constructed to flip in each step the current dimension i.e. to behave like arr[...,::-1,...]
     for i in range(template.ndim):
@@ -224,4 +224,3 @@ def template_ellipsoid(shape):
             template = numpy.concatenate((template[slicers][slicers_truncate], template), i)
 
     return template
-

--- a/medpy/filter/image.py
+++ b/medpy/filter/image.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -106,7 +106,7 @@ def sls(minuend, subtrahend, metric = "ssd", noise = "global", signed = True,
     pn_cval : scalar, optional
         Value to fill past edges of input if `pn_mode` is 'constant'. Default
         is 0.0
-        
+
     Returns
     -------
     sls : ndarray
@@ -114,7 +114,7 @@ def sls(minuend, subtrahend, metric = "ssd", noise = "global", signed = True,
 
     References
     ----------
-    
+
     .. [1] Mattias P. Heinrich, Mark Jenkinson, Manav Bhushan, Tahreema Matin, Fergus V. Gleeson, Sir Michael Brady, Julia A. Schnabel
            MIND: Modality independent neighbourhood descriptor for multi-modal deformable registration
            Medical Image Analysis, Volume 16, Issue 7, October 2012, Pages 1423-1435, ISSN 1361-8415
@@ -122,35 +122,35 @@ def sls(minuend, subtrahend, metric = "ssd", noise = "global", signed = True,
     """
     minuend = numpy.asarray(minuend)
     subtrahend = numpy.asarray(subtrahend)
-    
+
     if numpy.iscomplexobj(minuend):
         raise TypeError('complex type not supported')
     if numpy.iscomplexobj(subtrahend):
-        raise TypeError('complex type not supported')  
-    
+        raise TypeError('complex type not supported')
+
     mshape = [ii for ii in minuend.shape if ii > 0]
     sshape = [ii for ii in subtrahend.shape if ii > 0]
     if not len(mshape) == len(sshape):
         raise RuntimeError("minuend and subtrahend must be of same shape")
     if not numpy.all([sm == ss for sm, ss in zip(mshape, sshape)]):
         raise RuntimeError("minuend and subtrahend must be of same shape")
-    
+
     sn_footprint = __make_footprint(minuend, sn_size, sn_footprint)
     sn_fshape = [ii for ii in sn_footprint.shape if ii > 0]
     if len(sn_fshape) != minuend.ndim:
         raise RuntimeError('search neighbourhood footprint array has incorrect shape.')
-    
+
     #!TODO: Is this required?
     if not sn_footprint.flags.contiguous:
         sn_footprint = sn_footprint.copy()
-    
-    # created a padded copy of the subtrahend, whereas the padding mode is always 'reflect'  
+
+    # created a padded copy of the subtrahend, whereas the padding mode is always 'reflect'
     subtrahend = pad(subtrahend, footprint=sn_footprint, mode=sn_mode, cval=sn_cval)
-    
+
     # compute slicers for position where the search neighbourhood sn_footprint is TRUE
     slicers = [[slice(x, (x + 1) - d if 0 != (x + 1) - d else None) for x in range(d)] for d in sn_fshape]
     slicers = [sl for sl, tv in zip(itertools.product(*slicers), sn_footprint.flat) if tv]
-    
+
     # compute difference images and sign images for search neighbourhood elements
     ssds = [ssd(minuend, subtrahend[slicer], normalized=True, signed=signed, size=pn_size, footprint=pn_footprint, mode=pn_mode, cval=pn_cval) for slicer in slicers]
     distance = [x[0] for x in ssds]
@@ -162,23 +162,23 @@ def sls(minuend, subtrahend, metric = "ssd", noise = "global", signed = True,
     if 'global' == noise:
         variance = variance.sum() / float(numpy.product(variance.shape))
     # variance[variance < variance_global / 10.] = variance_global / 10. #!TODO: Should I keep this i.e. regularizing the variance to be at least 10% of the global one?
-    
+
     # compute sls
     sls = [dist_sign * numpy.exp(-1 * (dist / variance)) for dist_sign, dist in zip(distance_sign, distance)]
-    
+
     # convert into sls image, swapping dimensions to have varying patches in the last dimension
     return numpy.rollaxis(numpy.asarray(sls), 0, minuend.ndim + 1)
 
 def ssd(minuend, subtrahend, normalized=True, signed=False, size=None, footprint=None, mode="reflect", cval=0.0, origin=0):
     r"""
     Computes the sum of squared difference (SSD) between patches of minuend and subtrahend.
-    
+
     Parameters
     ----------
     minuend : array_like
         Input array from which to subtract the subtrahend.
     subtrahend : array_like
-        Input array to subtract from the minuend.    
+        Input array to subtract from the minuend.
     normalized : bool, optional
         Whether the SSD of each patch should be divided through the filter size for
         normalization. Default is 'True'.
@@ -207,15 +207,15 @@ def ssd(minuend, subtrahend, normalized=True, signed=False, size=None, footprint
     cval : scalar, optional
         Value to fill past edges of input if `mode` is 'constant'. Default
         is 0.0
-        
+
     Returns
     -------
     ssd : ndarray
         The patchwise sum of squared differences between minuend and subtrahend.
     """
     convolution_filter = average_filter if normalized else sum_filter
-    output = numpy.float if normalized else minuend.dtype
-    
+    output = float if normalized else minuend.dtype
+
     if signed:
         difference = minuend - subtrahend
         difference_squared = numpy.square(difference)
@@ -224,7 +224,7 @@ def ssd(minuend, subtrahend, normalized=True, signed=False, size=None, footprint
     else:
         distance = convolution_filter(numpy.square(minuend - subtrahend), size=size, footprint=footprint, mode=mode, cval=cval, origin=origin, output=output)
         distance_sign = 1
-    
+
     return distance, distance_sign
 
 def average_filter(input, size=None, footprint=None, output=None, mode="reflect", cval=0.0, origin=0):
@@ -277,7 +277,7 @@ def average_filter(input, size=None, footprint=None, output=None, mode="reflect"
     """
     footprint = __make_footprint(input, size, footprint)
     filter_size = footprint.sum()
-    
+
     output = _get_output(output, input)
     sum_filter(input, footprint=footprint, output=output, mode=mode, cval=cval, origin=origin)
     output /= filter_size
@@ -333,26 +333,26 @@ def sum_filter(input, size=None, footprint=None, output=None, mode="reflect", cv
     scipy.ndimage.convolve : Convolve an image with a kernel.
     """
     footprint = __make_footprint(input, size, footprint)
-    slicer = [slice(None, None, -1)] * footprint.ndim 
+    slicer = [slice(None, None, -1)] * footprint.ndim
     return convolve(input, footprint[slicer], output, mode, cval, origin)
 
 def otsu (img, bins=64):
     r"""
     Otsu's method to find the optimal threshold separating an image into fore- and background.
-    
+
     This rather expensive method iterates over a number of thresholds to separate the
     images histogram into two parts with a minimal intra-class variance.
-    
+
     An increase in the number of bins increases the algorithms specificity at the cost of
     slowing it down.
-    
+
     Parameters
     ----------
     img : array_like
         The image for which to determine the threshold.
     bins : integer
         The number of histogram bins.
-        
+
     Returns
     -------
     otsu : float
@@ -360,54 +360,54 @@ def otsu (img, bins=64):
     """
     # cast bins parameter to int
     bins = int(bins)
-    
+
     # cast img parameter to scipy arrax
     img = numpy.asarray(img)
-    
+
     # check supplied parameters
     if bins <= 1:
         raise AttributeError('At least a number two bins have to be provided.')
-    
+
     # determine initial threshold and threshold step-length
     steplength = (img.max() - img.min()) / float(bins)
     initial_threshold = img.min() + steplength
-    
+
     # initialize best value variables
     best_bcv = 0
     best_threshold = initial_threshold
-    
+
     # iterate over the thresholds and find highest between class variance
     for threshold in numpy.arange(initial_threshold, img.max(), steplength):
         mask_fg = (img >= threshold)
         mask_bg = (img < threshold)
-        
+
         wfg = numpy.count_nonzero(mask_fg)
         wbg = numpy.count_nonzero(mask_bg)
-        
+
         if 0 == wfg or 0 == wbg: continue
-        
+
         mfg = img[mask_fg].mean()
         mbg = img[mask_bg].mean()
-        
+
         bcv = wfg * wbg * math.pow(mbg - mfg, 2)
-        
+
         if bcv > best_bcv:
             best_bcv = bcv
             best_threshold = threshold
-        
+
     return best_threshold
 
 def local_minima(img, min_distance = 4):
     r"""
     Returns all local minima from an image.
-    
+
     Parameters
     ----------
     img : array_like
         The image.
     min_distance : integer
         The minimal distance between the minimas in voxels. If it is less, only the lower minima is returned.
-    
+
     Returns
     -------
     indices : sequence
@@ -427,7 +427,7 @@ def local_minima(img, min_distance = 4):
 def resample(img, hdr, target_spacing, bspline_order=3, mode='constant'):
         """
         Re-sample an image to a new voxel-spacing.
-        
+
         Parameters
         ----------
         img : array_like
@@ -440,11 +440,11 @@ def resample(img, hdr, target_spacing, bspline_order=3, mode='constant'):
             The bspline order used for interpolation.
         mode : str
             Points outside the boundaries of the input are filled according to the given mode ('constant', 'nearest', 'reflect' or 'wrap'). Default is 'constant'.
-            
+
         Warning
         -------
         Voxel-spacing of input header will be modified in-place!
-            
+
         Returns
         -------
         img : ndarray
@@ -454,14 +454,14 @@ def resample(img, hdr, target_spacing, bspline_order=3, mode='constant'):
         """
         if isinstance(target_spacing, numbers.Number):
             target_spacing = [target_spacing] * img.ndim
-        
+
         # compute zoom values
         zoom_factors = [old / float(new) for new, old in zip(target_spacing, header.get_pixel_spacing(hdr))]
-    
+
         # zoom image
         img = zoom(img, zoom_factors, order=bspline_order, mode=mode)
-        
+
         # set new voxel spacing
         header.set_pixel_spacing(hdr, target_spacing)
-        
+
         return img, hdr

--- a/medpy/filter/utilities.py
+++ b/medpy/filter/utilities.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -32,11 +32,11 @@ def xminus1d(img, fun, dim, *args, **kwargs):
     r"""
     Applies the function fun along all X-1D dimensional volumes of the images img
     dimension dim.
-    
+
     E.g. you want to apply a gauss filter to each slice of a 3D MRI brain image,
     simply supply the function as fun, the image as img and the dimension along which
     to iterate as dim.
-    
+
     Parameters
     ----------
     img : ndarray
@@ -45,12 +45,12 @@ def xminus1d(img, fun, dim, *args, **kwargs):
         A image modification function.
     dim : integer
         The dimension along which to apply the function.
-    
+
     Returns
     -------
     output : ndarray
         The result of the operation over the image ``img``.
-    
+
     Notes
     -----
     With ``*args`` and ``**kwargs``, arguments can be passed to the function ``fun``.
@@ -66,13 +66,13 @@ def xminus1d(img, fun, dim, *args, **kwargs):
 def pad(input, size=None, footprint=None, output=None, mode="reflect", cval=0.0):
     r"""
     Returns a copy of the input, padded by the supplied structuring element.
-    
+
     In the case of odd dimensionality, the structure element will be centered as
     following on the currently processed position::
-    
+
         [[T, Tx, T],
          [T, T , T]]
-         
+
     , where Tx denotes the center of the structure element.
 
     Simulates the behaviour of scipy.ndimage filters.
@@ -104,17 +104,17 @@ def pad(input, size=None, footprint=None, output=None, mode="reflect", cval=0.0)
     cval : scalar, optional
         Value to fill past edges of input if `mode` is 'constant'. Default
         is 0.0
-        
+
     Returns
     -------
     output : ndarray
         The padded version of the input image.
-        
+
     Notes
     -----
     Since version 1.7.0, numpy supplied a pad function `numpy.pad` that provides
     the same functionality and should be preferred.
-    
+
     Raises
     ------
     ValueError
@@ -131,7 +131,7 @@ def pad(input, size=None, footprint=None, output=None, mode="reflect", cval=0.0)
     fshape = [ii for ii in footprint.shape if ii > 0]
     if len(fshape) != input.ndim:
         raise RuntimeError('filter footprint array has incorrect shape.')
-    
+
     if numpy.any([x > 2*y for x, y in zip(footprint.shape, input.shape)]):
         raise ValueError('The size of the padding element is not allowed to be more than double the size of the input array in any dimension.')
 
@@ -168,7 +168,7 @@ def pad(input, size=None, footprint=None, output=None, mode="reflect", cval=0.0)
         reverse_slice = slice(None)
     else:
         raise RuntimeError('boundary mode not supported')
-    
+
     output[input_slicer] = input
     for dim, to_slice, from_slice in dim_slices:
         slicer_reverse = [reverse_slice if d == dim else slice(None) for d in range(output.ndim)]
@@ -182,10 +182,10 @@ def intersection(i1, h1, i2, h2):
         r"""
         Returns the intersecting parts of two images in real world coordinates.
         Takes both, voxelspacing and image offset into account.
-        
+
         Note that the returned new offset might be inaccurate up to 1/2 voxel size for
         each dimension due to averaging.
-        
+
         Parameters
         ----------
         i1 : array_like
@@ -194,7 +194,7 @@ def intersection(i1, h1, i2, h2):
         h1 : MedPy image header
         h2 : MedPy image header
             The corresponding headers.
-            
+
         Returns
         -------
         v1 : ndarray
@@ -204,24 +204,24 @@ def intersection(i1, h1, i2, h2):
         offset : tuple of floats
             The new offset of ``v1`` and ``v2`` in real world coordinates.
         """
-        
+
         # compute image bounding boxes in real-world coordinates
         os1 = numpy.asarray(header.get_offset(h1))
         ps1 = numpy.asarray(header.get_pixel_spacing(h1))
         bb1 = (os1, numpy.asarray(i1.shape) * ps1 + os1)
-        
-        
+
+
         os2 = numpy.asarray(header.get_offset(h2))
         ps2 = numpy.asarray(header.get_pixel_spacing(h2))
         bb2 = (os2, numpy.asarray(i2.shape) * ps2 + os2)
-        
+
         # compute intersection
         ib = (numpy.maximum(bb1[0], bb2[0]), numpy.minimum(bb1[1], bb2[1]))
-        
+
         # transfer intersection to respective image coordinates image
-        ib1 = [ ((ib[0] - os1) / numpy.asarray(ps1)).astype(numpy.int), ((ib[1] - os1) / numpy.asarray(ps1)).astype(numpy.int) ]
-        ib2 = [ ((ib[0] - os2) / numpy.asarray(ps2)).astype(numpy.int), ((ib[1] - os2) / numpy.asarray(ps2)).astype(numpy.int) ]
-        
+        ib1 = [ ((ib[0] - os1) / numpy.asarray(ps1)).astype(int), ((ib[1] - os1) / numpy.asarray(ps1)).astype(int) ]
+        ib2 = [ ((ib[0] - os2) / numpy.asarray(ps2)).astype(int), ((ib[1] - os2) / numpy.asarray(ps2)).astype(int) ]
+
         # ensure that both sub-volumes are of same size (might be affected by rounding errors); only reduction allowed
         s1 = ib1[1] - ib1[0]
         s2 = ib2[1] - ib2[0]
@@ -231,16 +231,16 @@ def intersection(i1, h1, i2, h2):
         d2[d2 > 0] = 0
         ib1[1] -= d1
         ib2[1] -= d2
-        
+
         # compute new image offsets (in real-world coordinates); averaged to account for rounding errors due to world-to-voxel mapping
         nos1 = ib1[0] * ps1 + os1 # real offset for image 1
         nos2 = ib2[0] * ps2 + os2 # real offset for image 2
         nos = numpy.average([nos1, nos2], 0)
-        
+
         # build slice lists
         sl1 = [slice(l, u) for l, u in zip(*ib1)]
         sl2 = [slice(l, u) for l, u in zip(*ib2)]
-        
+
         return i1[sl1], i2[sl2], nos
 
 def __make_footprint(input, size, footprint):

--- a/medpy/graphcut/__init__.py
+++ b/medpy/graphcut/__init__.py
@@ -10,7 +10,7 @@ the Dimacs graph standard [5]_ and/or processed (i.e. cut) using 3rd party graph
 algorithms.
 
 This module makes use of a custom *Boost.Python* [2]_ wrapper written for a modified
-version of Boykov and Kolmogorovs max-flow/min-cut algorithm (v3.01) [4]_ that can be found at [3]_. 
+version of Boykov and Kolmogorovs max-flow/min-cut algorithm (v3.01) [4]_ that can be found at [3]_.
 
 Supports voxel- as well as label/region-based graph-cuts.
 
@@ -25,21 +25,21 @@ Use together with an energy term from :mod:`~medpy.graphcut.energy_voxel` respec
 .. module:: medpy.graphcut.generate
 .. autosummary::
     :toctree: generated/
-    
+
     graph_from_voxels
     graph_from_labels
-    
+
 Energy terms for voxel-based graph-cuts :mod:`medpy.graphcut.energy_voxel`
 ==========================================================================
 Run-time optimized energy functions for the graph generation. Voxel based [7]_.
 
 .. module:: medpy.graphcut.energy_voxel
-    
+
 Boundary energy terms
 ---------------------
 .. autosummary::
-    :toctree: generated/    
-    
+    :toctree: generated/
+
     boundary_maximum_linear
     boundary_difference_linear
     boundary_maximum_exponential
@@ -48,14 +48,14 @@ Boundary energy terms
     boundary_difference_division
     boundary_maximum_power
     boundary_difference_power
-    
+
 Regional energy terms
 ---------------------
 .. autosummary::
     :toctree: generated/
-    
+
     regional_probability_map
-    
+
 Energy terms for label-based graph-cuts :mod:`medpy.graphcut.energy_label`
 ==========================================================================
 Run-time optimized energy functions for the graph generation. Label/Superpixel based [6]_.
@@ -65,18 +65,18 @@ Run-time optimized energy functions for the graph generation. Label/Superpixel b
 Boundary energy terms
 ---------------------
 .. autosummary::
-    :toctree: generated/    
-    
+    :toctree: generated/
+
     boundary_difference_of_means
     boundary_stawiaski
     boundary_stawiaski_directed
-    
+
 Regional energy terms
 ---------------------
 .. autosummary::
     :toctree: generated/
-    
-    regional_atlas    
+
+    regional_atlas
 
 Persist a graph :mod:`medpy.graphcut.write`
 ===========================================
@@ -85,7 +85,7 @@ Functions to persist a graph in file formats like Dimacs [5]_, which can be read
 .. module:: medpy.graphcut.write
 .. autosummary::
     :toctree: generated/
-    
+
     graph_to_dimacs
 
 Graph :mod:`medpy.graphcut.graph`
@@ -95,10 +95,10 @@ Graph objects that can be used to generate a custom graph and execute a graph-cu
 .. module:: medpy.graphcut.graph
 .. autosummary::
     :toctree: generated/
-    
+
     GCGraph
     Graph
-    
+
 Maxflow :mod:`medpy.graphcut.maxflow`
 =====================================
 C++ wrapper around the max-flow/min-cut implementation of [4]_ using Boost.Python.
@@ -107,11 +107,11 @@ Do not use these directly, but rather the graph objects supplied by :mod:`medpy.
 .. module:: medpy.graphcut.maxflow
 .. autosummary::
     :toctree: generated/
-    
+
     GraphDouble
     GraphFloat
     GraphInt
-    
+
 Wrapper :mod:`medpy.graphcut.wrapper`
 =====================================
 Wrappers for executing graph cuts in a memory-friendly way and other convenience functions.
@@ -119,7 +119,7 @@ Wrappers for executing graph cuts in a memory-friendly way and other convenience
 .. module:: medpy.graphcut.wrapper
 .. autosummary::
     :toctree: generated/
-    
+
     split_marker
     graphcut_split
     graphcut_subprocesses
@@ -159,9 +159,9 @@ Executing the graph-cut (depending on the image size, this might take a while).
 Building the resulting segmentation image, with True values for foreground and False
 values for background voxels.
 
->>> result_image_data = numpy.zeros(image_data.size, dtype=numpy.bool)
+>>> result_image_data = numpy.zeros(image_data.size, dtype=numpy.bool_)
 >>> for idx in range(len(result_image_data)):
-        result_image_data[idx] = 0 if gcgraph.termtype.SINK == gcgraph.what_segment(idx) else 1    
+        result_image_data[idx] = 0 if gcgraph.termtype.SINK == gcgraph.what_segment(idx) else 1
 >>> result_image_data = result_image_data.reshape(image_data.shape)
 
 
@@ -182,17 +182,17 @@ References
 """
 
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/medpy/metric/binary.py
+++ b/medpy/metric/binary.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -34,18 +34,18 @@ from scipy.stats import pearsonr
 def dc(result, reference):
     r"""
     Dice coefficient
-    
+
     Computes the Dice coefficient (also known as Sorensen index) between the binary
     objects in two images.
-    
+
     The metric is defined as
-    
+
     .. math::
-        
+
         DC=\frac{2|A\cap B|}{|A|+|B|}
-        
+
     , where :math:`A` is the first and :math:`B` the second set of samples (here: binary objects).
-    
+
     Parameters
     ----------
     result : array_like
@@ -54,38 +54,38 @@ def dc(result, reference):
     reference : array_like
         Input data containing objects. Can be any type but will be converted
         into binary: background where 0, object everywhere else.
-    
+
     Returns
     -------
     dc : float
         The Dice coefficient between the object(s) in ```result``` and the
         object(s) in ```reference```. It ranges from 0 (no overlap) to 1 (perfect overlap).
-        
+
     Notes
     -----
     This is a real metric. The binary images can therefore be supplied in any order.
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-    
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     intersection = numpy.count_nonzero(result & reference)
-    
+
     size_i1 = numpy.count_nonzero(result)
     size_i2 = numpy.count_nonzero(reference)
-    
+
     try:
         dc = 2. * intersection / float(size_i1 + size_i2)
     except ZeroDivisionError:
         dc = 1.0
-    
+
     return dc
 
 def jc(result, reference):
     """
     Jaccard coefficient
-    
+
     Computes the Jaccard coefficient between the binary objects in two images.
-    
+
     Parameters
     ----------
     result: array_like
@@ -100,28 +100,28 @@ def jc(result, reference):
     jc: float
         The Jaccard coefficient between the object(s) in `result` and the
         object(s) in `reference`. It ranges from 0 (no overlap) to 1 (perfect overlap).
-    
+
     Notes
     -----
     This is a real metric. The binary images can therefore be supplied in any order.
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-    
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     intersection = numpy.count_nonzero(result & reference)
     union = numpy.count_nonzero(result | reference)
-    
+
     try:
         jc = float(intersection) / float(union)
     except ZeroDivisionError:
         jc = 1.0
-    
+
     return jc
 
 def precision(result, reference):
     """
     Precison.
-    
+
     Parameters
     ----------
     result : array_like
@@ -130,45 +130,45 @@ def precision(result, reference):
     reference : array_like
         Input data containing objects. Can be any type but will be converted
         into binary: background where 0, object everywhere else.
-    
+
     Returns
     -------
     precision : float
         The precision between two binary datasets, here mostly binary objects in images,
         which is defined as the fraction of retrieved instances that are relevant. The
         precision is not symmetric.
-    
+
     See also
     --------
     :func:`recall`
-    
+
     Notes
     -----
     Not symmetric. The inverse of the precision is :func:`recall`.
     High precision means that an algorithm returned substantially more relevant results than irrelevant.
-    
+
     References
     ----------
     .. [1] http://en.wikipedia.org/wiki/Precision_and_recall
     .. [2] http://en.wikipedia.org/wiki/Confusion_matrix#Table_of_confusion
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-        
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     tp = numpy.count_nonzero(result & reference)
     fp = numpy.count_nonzero(result & ~reference)
-    
+
     try:
         precision = tp / float(tp + fp)
     except ZeroDivisionError:
         precision = 0.0
-    
+
     return precision
 
 def recall(result, reference):
     """
     Recall.
-    
+
     Parameters
     ----------
     result : array_like
@@ -177,31 +177,31 @@ def recall(result, reference):
     reference : array_like
         Input data containing objects. Can be any type but will be converted
         into binary: background where 0, object everywhere else.
-    
+
     Returns
     -------
     recall : float
         The recall between two binary datasets, here mostly binary objects in images,
         which is defined as the fraction of relevant instances that are retrieved. The
         recall is not symmetric.
-    
+
     See also
     --------
     :func:`precision`
-    
+
     Notes
     -----
     Not symmetric. The inverse of the recall is :func:`precision`.
     High recall means that an algorithm returned most of the relevant results.
-    
+
     References
     ----------
     .. [1] http://en.wikipedia.org/wiki/Precision_and_recall
     .. [2] http://en.wikipedia.org/wiki/Confusion_matrix#Table_of_confusion
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-        
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     tp = numpy.count_nonzero(result & reference)
     fn = numpy.count_nonzero(~result & reference)
 
@@ -209,24 +209,24 @@ def recall(result, reference):
         recall = tp / float(tp + fn)
     except ZeroDivisionError:
         recall = 0.0
-    
+
     return recall
 
 def sensitivity(result, reference):
     """
     Sensitivity.
     Same as :func:`recall`, see there for a detailed description.
-    
+
     See also
     --------
-    :func:`specificity` 
+    :func:`specificity`
     """
     return recall(result, reference)
 
 def specificity(result, reference):
     """
     Specificity.
-    
+
     Parameters
     ----------
     result : array_like
@@ -235,31 +235,31 @@ def specificity(result, reference):
     reference : array_like
         Input data containing objects. Can be any type but will be converted
         into binary: background where 0, object everywhere else.
-    
+
     Returns
     -------
     specificity : float
         The specificity between two binary datasets, here mostly binary objects in images,
         which denotes the fraction of correctly returned negatives. The
         specificity is not symmetric.
-    
+
     See also
     --------
     :func:`sensitivity`
-    
+
     Notes
     -----
     Not symmetric. The completment of the specificity is :func:`sensitivity`.
     High recall means that an algorithm returned most of the irrelevant results.
-    
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Sensitivity_and_specificity
     .. [2] http://en.wikipedia.org/wiki/Confusion_matrix#Table_of_confusion
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-       
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     tn = numpy.count_nonzero(~result & ~reference)
     fp = numpy.count_nonzero(result & ~reference)
 
@@ -267,17 +267,17 @@ def specificity(result, reference):
         specificity = tn / float(tn + fp)
     except ZeroDivisionError:
         specificity = 0.0
-    
+
     return specificity
 
 def true_negative_rate(result, reference):
     """
     True negative rate.
     Same as :func:`specificity`, see there for a detailed description.
-    
+
     See also
     --------
-    :func:`true_positive_rate` 
+    :func:`true_positive_rate`
     :func:`positive_predictive_value`
     """
     return specificity(result, reference)
@@ -286,10 +286,10 @@ def true_positive_rate(result, reference):
     """
     True positive rate.
     Same as :func:`recall` and :func:`sensitivity`, see there for a detailed description.
-    
+
     See also
     --------
-    :func:`positive_predictive_value` 
+    :func:`positive_predictive_value`
     :func:`true_negative_rate`
     """
     return recall(result, reference)
@@ -298,7 +298,7 @@ def positive_predictive_value(result, reference):
     """
     Positive predictive value.
     Same as :func:`precision`, see there for a detailed description.
-    
+
     See also
     --------
     :func:`true_positive_rate`
@@ -309,10 +309,10 @@ def positive_predictive_value(result, reference):
 def hd(result, reference, voxelspacing=None, connectivity=1):
     """
     Hausdorff Distance.
-    
+
     Computes the (symmetric) Hausdorff Distance (HD) between the binary objects in two
     images. It is defined as the maximum surface distance between the objects.
-    
+
     Parameters
     ----------
     result : array_like
@@ -331,19 +331,19 @@ def hd(result, reference, voxelspacing=None, connectivity=1):
         of the binary objects. This value is passed to
         `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         Note that the connectivity influences the result in the case of the Hausdorff distance.
-        
+
     Returns
     -------
     hd : float
         The symmetric Hausdorff Distance between the object(s) in ```result``` and the
-        object(s) in ```reference```. The distance unit is the same as for the spacing of 
+        object(s) in ```reference```. The distance unit is the same as for the spacing of
         elements along each dimension, which is usually given in mm.
-        
+
     See also
     --------
     :func:`assd`
     :func:`asd`
-    
+
     Notes
     -----
     This is a real metric. The binary images can therefore be supplied in any order.
@@ -385,7 +385,7 @@ def hd95(result, reference, voxelspacing=None, connectivity=1):
     -------
     hd : float
         The symmetric Hausdorff Distance between the object(s) in ```result``` and the
-        object(s) in ```reference```. The distance unit is the same as for the spacing of 
+        object(s) in ```reference```. The distance unit is the same as for the spacing of
         elements along each dimension, which is usually given in mm.
 
     See also
@@ -405,63 +405,10 @@ def hd95(result, reference, voxelspacing=None, connectivity=1):
 def assd(result, reference, voxelspacing=None, connectivity=1):
     """
     Average symmetric surface distance.
-    
+
     Computes the average symmetric surface distance (ASD) between the binary objects in
     two images.
-    
-    Parameters
-    ----------
-    result : array_like
-        Input data containing objects. Can be any type but will be converted
-        into binary: background where 0, object everywhere else.
-    reference : array_like
-        Input data containing objects. Can be any type but will be converted
-        into binary: background where 0, object everywhere else.
-    voxelspacing : float or sequence of floats, optional
-        The voxelspacing in a distance unit i.e. spacing of elements
-        along each dimension. If a sequence, must be of length equal to
-        the input rank; if a single number, this is used for all axes. If
-        not specified, a grid spacing of unity is implied.
-    connectivity : int
-        The neighbourhood/connectivity considered when determining the surface
-        of the binary objects. This value is passed to
-        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
-        The decision on the connectivity is important, as it can influence the results
-        strongly. If in doubt, leave it as it is.         
-        
-    Returns
-    -------
-    assd : float
-        The average symmetric surface distance between the object(s) in ``result`` and the
-        object(s) in ``reference``. The distance unit is the same as for the spacing of 
-        elements along each dimension, which is usually given in mm.
-        
-    See also
-    --------
-    :func:`asd`
-    :func:`hd`
-    
-    Notes
-    -----
-    This is a real metric, obtained by calling
-    
-    >>> __surface_distances(result, reference)
-    
-    and
-    
-    >>> __surface_distances(reference, result)
-    
-    and then averaging the two lists. The binary images can therefore be supplied in any order.
-    """
-    assd = numpy.mean( (__surface_distances(result, reference, voxelspacing, connectivity), __surface_distances(reference, result, voxelspacing, connectivity)) )
-    return assd
 
-def asd(result, reference, voxelspacing=None, connectivity=1):
-    """
-    Average surface distance metric.
-    
-    Computes the average surface distance (ASD) between the binary objects in two images.
-    
     Parameters
     ----------
     result : array_like
@@ -481,97 +428,40 @@ def asd(result, reference, voxelspacing=None, connectivity=1):
         `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
-    
+
     Returns
     -------
-    asd : float
-        The average surface distance between the object(s) in ``result`` and the
-        object(s) in ``reference``. The distance unit is the same as for the spacing
-        of elements along each dimension, which is usually given in mm.
-        
+    assd : float
+        The average symmetric surface distance between the object(s) in ``result`` and the
+        object(s) in ``reference``. The distance unit is the same as for the spacing of
+        elements along each dimension, which is usually given in mm.
+
     See also
     --------
-    :func:`assd`
+    :func:`asd`
     :func:`hd`
-    
-    
+
     Notes
     -----
-    This is not a real metric, as it is directed. See `assd` for a real metric of this.
-    
-    The method is implemented making use of distance images and simple binary morphology
-    to achieve high computational speed.
-    
-    Examples
-    --------
-    The `connectivity` determines what pixels/voxels are considered the surface of a
-    binary object. Take the following binary image showing a cross
-    
-    >>> from scipy.ndimage import generate_binary_structure
-    >>> cross = generate_binary_structure(2, 1)
-    array([[0, 1, 0],
-           [1, 1, 1],
-           [0, 1, 0]])
-           
-    With `connectivity` set to `1` a 4-neighbourhood is considered when determining the
-    object surface, resulting in the surface
-    
-    .. code-block:: python
-    
-        array([[0, 1, 0],
-               [1, 0, 1],
-               [0, 1, 0]])
-           
-    Changing `connectivity` to `2`, a 8-neighbourhood is considered and we get:
-    
-    .. code-block:: python
-    
-        array([[0, 1, 0],
-               [1, 1, 1],
-               [0, 1, 0]])
-           
-    , as a diagonal connection does no longer qualifies as valid object surface.
-    
-    This influences the  results `asd` returns. Imagine we want to compute the surface
-    distance of our cross to a cube-like object:
-    
-    >>> cube = generate_binary_structure(2, 1)
-    array([[1, 1, 1],
-           [1, 1, 1],
-           [1, 1, 1]])
-           
-    , which surface is, independent of the `connectivity` value set, always
-    
-    .. code-block:: python
-    
-        array([[1, 1, 1],
-               [1, 0, 1],
-               [1, 1, 1]])
-           
-    Using a `connectivity` of `1` we get
-    
-    >>> asd(cross, cube, connectivity=1)
-    0.0
-    
-    while a value of `2` returns us
-    
-    >>> asd(cross, cube, connectivity=2)
-    0.20000000000000001
-    
-    due to the center of the cross being considered surface as well.
-    
-    """
-    sds = __surface_distances(result, reference, voxelspacing, connectivity)
-    asd = sds.mean()
-    return asd
+    This is a real metric, obtained by calling
 
-def ravd(result, reference):
+    >>> __surface_distances(result, reference)
+
+    and
+
+    >>> __surface_distances(reference, result)
+
+    and then averaging the two lists. The binary images can therefore be supplied in any order.
     """
-    Relative absolute volume difference.
-    
-    Compute the relative absolute volume difference between the (joined) binary objects
-    in the two images.
-    
+    assd = numpy.mean( (__surface_distances(result, reference, voxelspacing, connectivity), __surface_distances(reference, result, voxelspacing, connectivity)) )
+    return assd
+
+def asd(result, reference, voxelspacing=None, connectivity=1):
+    """
+    Average surface distance metric.
+
+    Computes the average surface distance (ASD) between the binary objects in two images.
+
     Parameters
     ----------
     result : array_like
@@ -580,36 +470,146 @@ def ravd(result, reference):
     reference : array_like
         Input data containing objects. Can be any type but will be converted
         into binary: background where 0, object everywhere else.
-        
+    voxelspacing : float or sequence of floats, optional
+        The voxelspacing in a distance unit i.e. spacing of elements
+        along each dimension. If a sequence, must be of length equal to
+        the input rank; if a single number, this is used for all axes. If
+        not specified, a grid spacing of unity is implied.
+    connectivity : int
+        The neighbourhood/connectivity considered when determining the surface
+        of the binary objects. This value is passed to
+        `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
+        The decision on the connectivity is important, as it can influence the results
+        strongly. If in doubt, leave it as it is.
+
+    Returns
+    -------
+    asd : float
+        The average surface distance between the object(s) in ``result`` and the
+        object(s) in ``reference``. The distance unit is the same as for the spacing
+        of elements along each dimension, which is usually given in mm.
+
+    See also
+    --------
+    :func:`assd`
+    :func:`hd`
+
+
+    Notes
+    -----
+    This is not a real metric, as it is directed. See `assd` for a real metric of this.
+
+    The method is implemented making use of distance images and simple binary morphology
+    to achieve high computational speed.
+
+    Examples
+    --------
+    The `connectivity` determines what pixels/voxels are considered the surface of a
+    binary object. Take the following binary image showing a cross
+
+    >>> from scipy.ndimage import generate_binary_structure
+    >>> cross = generate_binary_structure(2, 1)
+    array([[0, 1, 0],
+           [1, 1, 1],
+           [0, 1, 0]])
+
+    With `connectivity` set to `1` a 4-neighbourhood is considered when determining the
+    object surface, resulting in the surface
+
+    .. code-block:: python
+
+        array([[0, 1, 0],
+               [1, 0, 1],
+               [0, 1, 0]])
+
+    Changing `connectivity` to `2`, a 8-neighbourhood is considered and we get:
+
+    .. code-block:: python
+
+        array([[0, 1, 0],
+               [1, 1, 1],
+               [0, 1, 0]])
+
+    , as a diagonal connection does no longer qualifies as valid object surface.
+
+    This influences the  results `asd` returns. Imagine we want to compute the surface
+    distance of our cross to a cube-like object:
+
+    >>> cube = generate_binary_structure(2, 1)
+    array([[1, 1, 1],
+           [1, 1, 1],
+           [1, 1, 1]])
+
+    , which surface is, independent of the `connectivity` value set, always
+
+    .. code-block:: python
+
+        array([[1, 1, 1],
+               [1, 0, 1],
+               [1, 1, 1]])
+
+    Using a `connectivity` of `1` we get
+
+    >>> asd(cross, cube, connectivity=1)
+    0.0
+
+    while a value of `2` returns us
+
+    >>> asd(cross, cube, connectivity=2)
+    0.20000000000000001
+
+    due to the center of the cross being considered surface as well.
+
+    """
+    sds = __surface_distances(result, reference, voxelspacing, connectivity)
+    asd = sds.mean()
+    return asd
+
+def ravd(result, reference):
+    """
+    Relative absolute volume difference.
+
+    Compute the relative absolute volume difference between the (joined) binary objects
+    in the two images.
+
+    Parameters
+    ----------
+    result : array_like
+        Input data containing objects. Can be any type but will be converted
+        into binary: background where 0, object everywhere else.
+    reference : array_like
+        Input data containing objects. Can be any type but will be converted
+        into binary: background where 0, object everywhere else.
+
     Returns
     -------
     ravd : float
         The relative absolute volume difference between the object(s) in ``result``
         and the object(s) in ``reference``. This is a percentage value in the range
         :math:`[-1.0, +inf]` for which a :math:`0` denotes an ideal score.
-        
+
     Raises
     ------
     RuntimeError
         If the reference object is empty.
-        
+
     See also
     --------
     :func:`dc`
     :func:`precision`
     :func:`recall`
-    
+
     Notes
     -----
     This is not a real metric, as it is directed. Negative values denote a smaller
     and positive values a larger volume than the reference.
     This implementation does not check, whether the two supplied arrays are of the same
     size.
-    
+
     Examples
     --------
     Considering the following inputs
-    
+
     >>> import numpy
     >>> arr1 = numpy.asarray([[0,1,0],[1,1,1],[0,1,0]])
     >>> arr1
@@ -621,45 +621,45 @@ def ravd(result, reference):
     array([[0, 1, 0],
            [1, 0, 1],
            [0, 1, 0]])
-           
+
     comparing `arr1` to `arr2` we get
-    
+
     >>> ravd(arr1, arr2)
     -0.2
-    
+
     and reversing the inputs the directivness of the metric becomes evident
-    
+
     >>> ravd(arr2, arr1)
     0.25
-    
+
     It is important to keep in mind that a perfect score of `0` does not mean that the
     binary objects fit exactely, as only the volumes are compared:
-    
+
     >>> arr1 = numpy.asarray([1,0,0])
     >>> arr2 = numpy.asarray([0,0,1])
     >>> ravd(arr1, arr2)
     0.0
-    
+
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-        
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     vol1 = numpy.count_nonzero(result)
     vol2 = numpy.count_nonzero(reference)
-    
+
     if 0 == vol2:
         raise RuntimeError('The second supplied array does not contain any binary object.')
-    
+
     return (vol1 - vol2) / float(vol2)
 
 def volume_correlation(results, references):
     r"""
     Volume correlation.
-    
+
     Computes the linear correlation in binary object volume between the
     contents of the successive binary images supplied. Measured through
-    the Pearson product-moment correlation coefficient. 
-    
+    the Pearson product-moment correlation coefficient.
+
     Parameters
     ----------
     results : sequence of array_like
@@ -669,31 +669,31 @@ def volume_correlation(results, references):
         Ordered list of input data containing objects. Each array_like will be
         converted into binary: background where 0, object everywhere else.
         The order must be the same as for ``results``.
-    
+
     Returns
     -------
     r : float
         The correlation coefficient between -1 and 1.
     p : float
         The two-side p value.
-        
+
     """
-    results = numpy.atleast_2d(numpy.array(results).astype(numpy.bool))
-    references = numpy.atleast_2d(numpy.array(references).astype(numpy.bool))
-    
+    results = numpy.atleast_2d(numpy.array(results).astype(numpy.bool_))
+    references = numpy.atleast_2d(numpy.array(references).astype(numpy.bool_))
+
     results_volumes = [numpy.count_nonzero(r) for r in results]
     references_volumes = [numpy.count_nonzero(r) for r in references]
-    
+
     return pearsonr(results_volumes, references_volumes) # returns (Pearson'
 
 def volume_change_correlation(results, references):
     r"""
     Volume change correlation.
-    
+
     Computes the linear correlation of change in binary object volume between
     the contents of the successive binary images supplied. Measured through
-    the Pearson product-moment correlation coefficient. 
-    
+    the Pearson product-moment correlation coefficient.
+
     Parameters
     ----------
     results : sequence of array_like
@@ -703,33 +703,33 @@ def volume_change_correlation(results, references):
         Ordered list of input data containing objects. Each array_like will be
         converted into binary: background where 0, object everywhere else.
         The order must be the same as for ``results``.
-    
+
     Returns
     -------
     r : float
         The correlation coefficient between -1 and 1.
     p : float
         The two-side p value.
-        
+
     """
-    results = numpy.atleast_2d(numpy.array(results).astype(numpy.bool))
-    references = numpy.atleast_2d(numpy.array(references).astype(numpy.bool))
-    
+    results = numpy.atleast_2d(numpy.array(results).astype(numpy.bool_))
+    references = numpy.atleast_2d(numpy.array(references).astype(numpy.bool_))
+
     results_volumes = numpy.asarray([numpy.count_nonzero(r) for r in results])
     references_volumes = numpy.asarray([numpy.count_nonzero(r) for r in references])
-    
+
     results_volumes_changes = results_volumes[1:] - results_volumes[:-1]
-    references_volumes_changes = references_volumes[1:] - references_volumes[:-1] 
-    
+    references_volumes_changes = references_volumes[1:] - references_volumes[:-1]
+
     return pearsonr(results_volumes_changes, references_volumes_changes) # returns (Pearson's correlation coefficient, 2-tailed p-value)
-    
+
 def obj_assd(result, reference, voxelspacing=None, connectivity=1):
     """
     Average symmetric surface distance.
-    
+
     Computes the average symmetric surface distance (ASSD) between the binary objects in
     two images.
-    
+
     Parameters
     ----------
     result : array_like
@@ -750,28 +750,28 @@ def obj_assd(result, reference, voxelspacing=None, connectivity=1):
         `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
-        
+
     Returns
     -------
     assd : float
         The average symmetric surface distance between all mutually existing distinct
         binary object(s) in ``result`` and ``reference``. The distance unit is the same as for
         the spacing of elements along each dimension, which is usually given in mm.
-        
+
     See also
     --------
     :func:`obj_asd`
-    
+
     Notes
     -----
-    This is a real metric, obtained by calling 
-    
+    This is a real metric, obtained by calling
+
     >>> __obj_surface_distances(result, reference)
-    
+
     and
-    
+
     >>> __obj_surface_distances(reference, result)
-    
+
     and then averaging the two lists. The binary images can therefore be supplied in any order.
     """
     assd = numpy.mean( (__obj_surface_distances(result, reference, voxelspacing, connectivity), __obj_surface_distances(reference, result, voxelspacing, connectivity)) )
@@ -780,11 +780,11 @@ def obj_assd(result, reference, voxelspacing=None, connectivity=1):
 def obj_asd(result, reference, voxelspacing=None, connectivity=1):
     """
     Average surface distance between objects.
-    
+
     First correspondences between distinct binary objects in reference and result are
     established. Then the average surface distance is only computed between corresponding
     objects. Correspondence is defined as unique and at least one voxel overlap.
-    
+
     Parameters
     ----------
     result : array_like
@@ -805,28 +805,28 @@ def obj_asd(result, reference, voxelspacing=None, connectivity=1):
         `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
-        
+
     Returns
     -------
     asd : float
         The average surface distance between all mutually existing distinct binary
         object(s) in ``result`` and ``reference``. The distance unit is the same as for the
         spacing of elements along each dimension, which is usually given in mm.
-        
+
     See also
     --------
     :func:`obj_assd`
     :func:`obj_tpr`
     :func:`obj_fpr`
-        
+
     Notes
     -----
     This is not a real metric, as it is directed. See `obj_assd` for a real metric of this.
-    
+
     For the understanding of this metric, both the notions of connectedness and surface
     distance are essential. Please see :func:`obj_tpr` and :func:`obj_fpr` for more
     information on the first and :func:`asd` on the second.
-        
+
     Examples
     --------
     >>> arr1 = numpy.asarray([[1,1,1],[1,1,1],[1,1,1]])
@@ -843,17 +843,17 @@ def obj_asd(result, reference, voxelspacing=None, connectivity=1):
     1.5
     >>> obj_asd(arr2, arr1)
     0.333333333333
-    
+
     With the `voxelspacing` parameter, the distances between the voxels can be set for
     each dimension separately:
-    
+
     >>> obj_asd(arr1, arr2, voxelspacing=(1,2))
     1.5
     >>> obj_asd(arr2, arr1, voxelspacing=(1,2))
-    0.333333333333    
-    
+    0.333333333333
+
     More examples depicting the notion of object connectedness:
-    
+
     >>> arr1 = numpy.asarray([[1,0,1],[1,0,0],[0,0,0]])
     >>> arr2 = numpy.asarray([[1,0,1],[1,0,0],[0,0,1]])
     >>> arr1
@@ -868,7 +868,7 @@ def obj_asd(result, reference, voxelspacing=None, connectivity=1):
     0.0
     >>> obj_asd(arr2, arr1)
     0.0
-    
+
     >>> arr1 = numpy.asarray([[1,0,1],[1,0,1],[0,0,1]])
     >>> arr2 = numpy.asarray([[1,0,1],[1,0,0],[0,0,1]])
     >>> arr1
@@ -883,12 +883,12 @@ def obj_asd(result, reference, voxelspacing=None, connectivity=1):
     0.6
     >>> obj_asd(arr2, arr1)
     0.0
-    
+
     Influence of `connectivity` parameter can be seen in the following example, where
     with the (default) connectivity of `1` the first array is considered to contain two
     objects, while with an increase connectivity of `2`, just one large object is
-    detected.  
-    
+    detected.
+
     >>> arr1 = numpy.asarray([[1,0,0],[0,1,1],[0,1,1]])
     >>> arr2 = numpy.asarray([[1,0,0],[0,0,0],[0,0,0]])
     >>> arr1
@@ -903,26 +903,26 @@ def obj_asd(result, reference, voxelspacing=None, connectivity=1):
     0.0
     >>> obj_asd(arr1, arr2, connectivity=2)
     1.742955328
-    
+
     Note that the connectivity also influence the notion of what is considered an object
     surface voxels.
     """
     sds = __obj_surface_distances(result, reference, voxelspacing, connectivity)
     asd = numpy.mean(sds)
     return asd
-    
+
 def obj_fpr(result, reference, connectivity=1):
     """
     The false positive rate of distinct binary object detection.
-    
+
     The false positive rates gives a percentage measure of how many distinct binary
     objects in the second array do not exists in the first array. A partial overlap
     (of minimum one voxel) is here considered sufficient.
-    
+
     In cases where two distinct binary object in the second array overlap with a single
     distinct object in the first array, only one is considered to have been detected
     successfully and the other is added to the count of false positives.
-    
+
     Parameters
     ----------
     result : array_like
@@ -937,23 +937,23 @@ def obj_fpr(result, reference, connectivity=1):
         `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
-        
+
     Returns
     -------
     tpr : float
         A percentage measure of how many distinct binary objects in ``results`` have no
         corresponding binary object in ``reference``. It has the range :math:`[0, 1]`, where a :math:`0`
         denotes an ideal score.
-        
+
     Raises
     ------
     RuntimeError
         If the second array is empty.
-    
+
     See also
     --------
     :func:`obj_tpr`
-    
+
     Notes
     -----
     This is not a real metric, as it is directed. Whatever array is considered as
@@ -961,7 +961,7 @@ def obj_fpr(result, reference, connectivity=1):
     distinct binary objects in the second array that do not exists also in the reference
     array, but does not reveal anything about objects in the reference array also
     existing in the second array (use :func:`obj_tpr` for this).
-    
+
     Examples
     --------
     >>> arr2 = numpy.asarray([[1,0,0],[1,0,1],[0,0,1]])
@@ -978,32 +978,32 @@ def obj_fpr(result, reference, connectivity=1):
     0.0
     >>> obj_fpr(arr2, arr1)
     0.0
-    
+
     Example of directedness:
-    
+
     >>> arr2 = numpy.asarray([1,0,1,0,1])
     >>> arr1 = numpy.asarray([1,0,1,0,0])
     >>> obj_fpr(arr1, arr2)
     0.0
     >>> obj_fpr(arr2, arr1)
     0.3333333333333333
-    
+
     Examples of multiple overlap treatment:
-    
+
     >>> arr2 = numpy.asarray([1,0,1,0,1,1,1])
     >>> arr1 = numpy.asarray([1,1,1,0,1,0,1])
     >>> obj_fpr(arr1, arr2)
     0.3333333333333333
     >>> obj_fpr(arr2, arr1)
     0.3333333333333333
-    
+
     >>> arr2 = numpy.asarray([1,0,1,1,1,0,1])
     >>> arr1 = numpy.asarray([1,1,1,0,1,1,1])
     >>> obj_fpr(arr1, arr2)
     0.0
     >>> obj_fpr(arr2, arr1)
     0.3333333333333333
-    
+
     >>> arr2 = numpy.asarray([[1,0,1,0,0],
                               [1,0,0,0,0],
                               [1,0,1,1,1],
@@ -1017,23 +1017,23 @@ def obj_fpr(result, reference, connectivity=1):
     >>> obj_fpr(arr1, arr2)
     0.0
     >>> obj_fpr(arr2, arr1)
-    0.2    
+    0.2
     """
     _, _, _, n_obj_reference, mapping = __distinct_binary_object_correspondences(reference, result, connectivity)
     return (n_obj_reference - len(mapping)) / float(n_obj_reference)
-    
+
 def obj_tpr(result, reference, connectivity=1):
     """
     The true positive rate of distinct binary object detection.
-    
+
     The true positive rates gives a percentage measure of how many distinct binary
     objects in the first array also exists in the second array. A partial overlap
     (of minimum one voxel) is here considered sufficient.
-    
+
     In cases where two distinct binary object in the first array overlaps with a single
     distinct object in the second array, only one is considered to have been detected
-    successfully.  
-    
+    successfully.
+
     Parameters
     ----------
     result : array_like
@@ -1048,22 +1048,22 @@ def obj_tpr(result, reference, connectivity=1):
         `scipy.ndimage.generate_binary_structure` and should usually be :math:`> 1`.
         The decision on the connectivity is important, as it can influence the results
         strongly. If in doubt, leave it as it is.
-        
+
     Returns
     -------
     tpr : float
         A percentage measure of how many distinct binary objects in ``result`` also exists
         in ``reference``. It has the range :math:`[0, 1]`, where a :math:`1` denotes an ideal score.
-        
+
     Raises
     ------
     RuntimeError
         If the reference object is empty.
-    
+
     See also
     --------
     :func:`obj_fpr`
-    
+
     Notes
     -----
     This is not a real metric, as it is directed. Whatever array is considered as
@@ -1071,7 +1071,7 @@ def obj_tpr(result, reference, connectivity=1):
     binary objects in the reference array also exist in the result array, but does not
     reveal anything about additional binary objects in the result array
     (use :func:`obj_fpr` for this).
-    
+
     Examples
     --------
     >>> arr2 = numpy.asarray([[1,0,0],[1,0,1],[0,0,1]])
@@ -1088,32 +1088,32 @@ def obj_tpr(result, reference, connectivity=1):
     1.0
     >>> obj_tpr(arr2, arr1)
     1.0
-    
+
     Example of directedness:
-    
+
     >>> arr2 = numpy.asarray([1,0,1,0,1])
     >>> arr1 = numpy.asarray([1,0,1,0,0])
     >>> obj_tpr(arr1, arr2)
     0.6666666666666666
     >>> obj_tpr(arr2, arr1)
     1.0
-    
+
     Examples of multiple overlap treatment:
-    
+
     >>> arr2 = numpy.asarray([1,0,1,0,1,1,1])
     >>> arr1 = numpy.asarray([1,1,1,0,1,0,1])
     >>> obj_tpr(arr1, arr2)
     0.6666666666666666
     >>> obj_tpr(arr2, arr1)
     0.6666666666666666
-    
+
     >>> arr2 = numpy.asarray([1,0,1,1,1,0,1])
     >>> arr1 = numpy.asarray([1,1,1,0,1,1,1])
     >>> obj_tpr(arr1, arr2)
     0.6666666666666666
     >>> obj_tpr(arr2, arr1)
     1.0
-    
+
     >>> arr2 = numpy.asarray([[1,0,1,0,0],
                               [1,0,0,0,0],
                               [1,0,1,1,1],
@@ -1127,7 +1127,7 @@ def obj_tpr(result, reference, connectivity=1):
     >>> obj_tpr(arr1, arr2)
     0.8
     >>> obj_tpr(arr2, arr1)
-    1.0    
+    1.0
     """
     _, _, n_obj_result, _, mapping = __distinct_binary_object_correspondences(reference, result, connectivity)
     return len(mapping) / float(n_obj_result)
@@ -1139,21 +1139,21 @@ def __distinct_binary_object_correspondences(reference, result, connectivity=1):
     parameters and returns a 1to1 mapping from the labelled objects in reference to the
     corresponding (whereas a one-voxel overlap suffices for correspondence) objects in
     result.
-    
+
     All stems from the problem, that the relationship is non-surjective many-to-many.
-    
+
     @return (labelmap1, labelmap2, n_lables1, n_labels2, labelmapping2to1)
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
-    
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
+
     # binary structure
     footprint = generate_binary_structure(result.ndim, connectivity)
-    
+
     # label distinct binary objects
     labelmap1, n_obj_result = label(result, footprint)
     labelmap2, n_obj_reference = label(reference, footprint)
-    
+
     # find all overlaps from labelmap2 to labelmap1; collect one-to-one relationships and store all one-two-many for later processing
     slicers = find_objects(labelmap2) # get windows of labelled objects
     mapping = dict() # mappings from labels in labelmap2 to corresponding object labels in labelmap1
@@ -1171,7 +1171,7 @@ def __distinct_binary_object_correspondences(reference, result, connectivity=1):
                 used_labels.add(l2id)
         elif 1 < len(l2ids): # one-to-many mapping: store relationship for later processing
             one_to_many.append((l1id, set(l2ids)))
-            
+
     # process one-to-many mappings, always choosing the one with the least labelmap2 correspondences first
     while True:
         one_to_many = [(l1id, l2ids - used_labels) for l1id, l2ids in one_to_many] # remove already used ids from all sets
@@ -1180,44 +1180,44 @@ def __distinct_binary_object_correspondences(reference, result, connectivity=1):
         if 0 == len(one_to_many):
             break
         l2id = one_to_many[0][1].pop() # select an arbitrary target label id from the shortest set
-        mapping[one_to_many[0][0]] = l2id # add to one-to-one mappings 
+        mapping[one_to_many[0][0]] = l2id # add to one-to-one mappings
         used_labels.add(l2id) # mark target label as used
         one_to_many = one_to_many[1:] # delete the processed set from all sets
-    
+
     return labelmap1, labelmap2, n_obj_result, n_obj_reference, mapping
-    
+
 def __surface_distances(result, reference, voxelspacing=None, connectivity=1):
     """
     The distances between the surface voxel of binary objects in result and their
     nearest partner surface voxel of a binary object in reference.
     """
-    result = numpy.atleast_1d(result.astype(numpy.bool))
-    reference = numpy.atleast_1d(reference.astype(numpy.bool))
+    result = numpy.atleast_1d(result.astype(numpy.bool_))
+    reference = numpy.atleast_1d(reference.astype(numpy.bool_))
     if voxelspacing is not None:
         voxelspacing = _ni_support._normalize_sequence(voxelspacing, result.ndim)
         voxelspacing = numpy.asarray(voxelspacing, dtype=numpy.float64)
         if not voxelspacing.flags.contiguous:
             voxelspacing = voxelspacing.copy()
-            
+
     # binary structure
     footprint = generate_binary_structure(result.ndim, connectivity)
-    
+
     # test for emptiness
-    if 0 == numpy.count_nonzero(result): 
+    if 0 == numpy.count_nonzero(result):
         raise RuntimeError('The first supplied array does not contain any binary object.')
-    if 0 == numpy.count_nonzero(reference): 
-        raise RuntimeError('The second supplied array does not contain any binary object.')    
-            
+    if 0 == numpy.count_nonzero(reference):
+        raise RuntimeError('The second supplied array does not contain any binary object.')
+
     # extract only 1-pixel border line of objects
     result_border = result ^ binary_erosion(result, structure=footprint, iterations=1)
     reference_border = reference ^ binary_erosion(reference, structure=footprint, iterations=1)
-    
-    # compute average surface distance        
+
+    # compute average surface distance
     # Note: scipys distance transform is calculated only inside the borders of the
     #       foreground objects, therefore the input has to be reversed
     dt = distance_transform_edt(~reference_border, sampling=voxelspacing)
     sds = dt[result_border]
-    
+
     return sds
 
 def __obj_surface_distances(result, reference, voxelspacing=None, connectivity=1):

--- a/medpy/neighbours/knn.py
+++ b/medpy/neighbours/knn.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2013 Oskar Maier
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -34,13 +34,13 @@ from scipy.sparse.csr import csr_matrix
 def mkneighbors_graph(observations, n_neighbours, metric, mode='connectivity', metric_params = None):
     """
     Computes the (weighted) graph of mutual k-Neighbors for observations.
-    
+
     Notes
     -----
     The distance between an observation and itself is never computed and instead set to
     ``numpy.inf``. I.e. only in the case of k>=n_observations or when the ``metric``
     returns ``numpy.inf``, the returned graph can contain loops.
-    
+
     Parameters
     ----------
     observations : sequence
@@ -55,7 +55,7 @@ def mkneighbors_graph(observations, n_neighbours, metric, mode='connectivity', m
         'both' returns a (connectivity, distance) tuple.
     metric_params : dict, optional  (default = None)
             Additional keyword arguments for the metric function.
-            
+
     Returns
     -------
     mkneighbors_graph : ndarray
@@ -67,40 +67,40 @@ def mkneighbors_graph(observations, n_neighbours, metric, mode='connectivity', m
     # compute their pairwise-distances
     pdists = pdist(observations, metric)
 
-    # get the k nearest neighbours for each patch 
+    # get the k nearest neighbours for each patch
     k_nearest_nbhs = numpy.argsort(pdists)[:,:n_neighbours]
-    
+
     # create a mask denoting the k nearest neighbours in image_pdist
-    k_nearest_mutual_nbhs_mask = numpy.zeros(pdists.shape, numpy.bool)
+    k_nearest_mutual_nbhs_mask = numpy.zeros(pdists.shape, numpy.bool_)
     for _mask_row, _nbhs_row in zip(k_nearest_mutual_nbhs_mask, k_nearest_nbhs):
         _mask_row[_nbhs_row] = True
-        
+
     # and with transposed to remove non-mutual nearest neighbours
     k_nearest_mutual_nbhs_mask &= k_nearest_mutual_nbhs_mask.T
-    
+
     # set distance not in the mutual k nearest neighbour set to zero
     pdists[~k_nearest_mutual_nbhs_mask] = 0
-    
+
     # check for edges with zero-weight
     if numpy.any(pdists[k_nearest_mutual_nbhs_mask] == 0):
         warnings.warn('The graph contains at least one edge with a weight of "0".')
-        
+
     if 'connectivity' == mode:
         return csr_matrix(k_nearest_mutual_nbhs_mask)
     elif 'distance' == mode:
         return csr_matrix(pdists)
     else:
         return csr_matrix(k_nearest_mutual_nbhs_mask), csr_matrix(pdists)
-            
+
 def pdist(objects, dmeasure, diagval = numpy.inf):
     """
     Compute the pair-wise distances between arbitrary objects.
-    
+
     Notes
     -----
     ``dmeasure`` is assumed to be *symmetry* i.e. between object *a* and object *b* the
     function will be called only ones.
-    
+
     Parameters
     ----------
     objects : sequence
@@ -109,13 +109,13 @@ def pdist(objects, dmeasure, diagval = numpy.inf):
         A callable function that takes two objects as input at returns a number.
     diagval : number
         The diagonal values of the resulting array.
-        
+
     Returns
     -------
     pdists : ndarray
         An *nxn* symmetric float array containing the pair-wise distances.
     """
-    out = numpy.zeros([len(objects)] * 2, numpy.float)
+    out = numpy.zeros([len(objects)] * 2, float)
     numpy.fill_diagonal(out, diagval)
     for idx1, idx2 in combinations(list(range(len(objects))), 2):
         out[idx1, idx2] = dmeasure(objects[idx1], objects[idx2])

--- a/tests/filter_/image.py
+++ b/tests/filter_/image.py
@@ -20,10 +20,10 @@ from scipy.ndimage import gaussian_filter
 
 # code
 class TestMetrics(unittest.TestCase):
-    
+
     def setUp(self):
         pass
-    
+
     def test_sls(self):
         m = numpy.array(
             [[0,0,0],
@@ -40,7 +40,7 @@ class TestMetrics(unittest.TestCase):
             [[1, 0],
              [1, 0],
              [0, 1]])
-        
+
         # reflect
         patches = [
             numpy.array(
@@ -57,23 +57,23 @@ class TestMetrics(unittest.TestCase):
                  [86,121,147]])]
         patches = [patch / 3. for patch in patches]
         noise = gaussian_filter(numpy.average(patches, 0), sigma=3)
-        e = [-1 * numpy.exp(-1 * patch / noise) for patch in patches]        
+        e = [-1 * numpy.exp(-1 * patch / noise) for patch in patches]
         e = numpy.rollaxis(numpy.asarray(e), 0, e[0].ndim + 1)
         r = sls(m, s, sn_footprint = sn_fp, pn_footprint = pn_fp, noise='local', signed=True)
         numpy.testing.assert_allclose(r, e)
-        
+
         e *= -1
         r = sls(m, -1 * s, sn_footprint = sn_fp, pn_footprint = pn_fp, noise='local', signed=True)
         numpy.testing.assert_allclose(r, e)
-        
+
         r = sls(m, s, sn_footprint = sn_fp, pn_footprint = pn_fp, noise='local', signed=False)
         numpy.testing.assert_allclose(r, e)
-        
+
         r = sls(m, -1 * s, sn_footprint = sn_fp, pn_footprint = pn_fp, noise='local', signed=False)
         numpy.testing.assert_allclose(r, e)
-        
+
         noise = noise.sum() / 9.
-        e = [-1 * numpy.exp(-1 * patch / noise) for patch in patches]        
+        e = [-1 * numpy.exp(-1 * patch / noise) for patch in patches]
         e = numpy.rollaxis(numpy.asarray(e), 0, e[0].ndim + 1)
         r = sls(m, s, sn_footprint = sn_fp, pn_footprint = pn_fp, noise='global', signed=True)
         numpy.testing.assert_allclose(r, e)
@@ -87,7 +87,7 @@ class TestMetrics(unittest.TestCase):
             [[1,2,3],
              [3,4,5],
              [5,6,7]])
-        
+
         e = numpy.array(
             [[ 1, 4, 9],
              [ 9,16,25],
@@ -95,7 +95,7 @@ class TestMetrics(unittest.TestCase):
         r, sgn = ssd(m, s, normalized=False, signed=False, size=1)
         self.assertEqual(sgn, 1, 'signed=False failed to return scalar 1')
         numpy.testing.assert_allclose(r, e)
-        
+
         esgn = numpy.array(
             [[-1,-1,-1],
              [-1,-1,-1],
@@ -103,7 +103,7 @@ class TestMetrics(unittest.TestCase):
         r, sgn = ssd(m, s, normalized=False, signed=True, size=1)
         numpy.testing.assert_allclose(sgn, esgn, err_msg = 'signed=True failed')
         numpy.testing.assert_allclose(r, e)
-        
+
         esgn = numpy.array(
             [[1,1,1],
              [1,1,1],
@@ -111,10 +111,10 @@ class TestMetrics(unittest.TestCase):
         r, sgn = ssd(s, m, normalized=False, signed=True, size=1)
         numpy.testing.assert_allclose(sgn, esgn, err_msg = 'signed=True failed')
         numpy.testing.assert_allclose(r, e)
-        
+
         r, _ = ssd(m, s, normalized=True, signed=False, size=1)
         numpy.testing.assert_allclose(r, e, err_msg='normalized=True failed')
-        
+
         fp = numpy.array(
             [[1, 0],
              [1, 0],
@@ -124,33 +124,33 @@ class TestMetrics(unittest.TestCase):
              [46,69,70],
              [50,77,90]])
         r, _ = ssd(m, s, normalized=False, signed=False, footprint=fp, mode='mirror')
-        numpy.testing.assert_allclose(r, e, err_msg='using footprint failed')      
-        
+        numpy.testing.assert_allclose(r, e, err_msg='using footprint failed')
+
         e = e / 3.
         r, _ = ssd(m, s, normalized=True, signed=False, footprint=fp, mode='mirror')
         numpy.testing.assert_allclose(r, e, err_msg='normalized=True using footprint failed')
-        
+
     def test_average_filter(self):
         i = numpy.array(
             [[1,2,3],
              [3,4,5],
              [5,6,7]])
-        
+
         fp = numpy.array(
             [[1, 1]])
         e = numpy.array(
             [[ 3, 5, 3],
              [ 7, 9, 5],
              [11,13, 7]])
-        r = average_filter(i, footprint=fp, mode='constant', cval=0, output=numpy.float)
+        r = average_filter(i, footprint=fp, mode='constant', cval=0, output=float)
         numpy.testing.assert_allclose(r, e / 2.)
-        
-        r = average_filter(i, footprint=fp, mode='constant', cval=0, output=numpy.int)
+
+        r = average_filter(i, footprint=fp, mode='constant', cval=0, output=int)
         numpy.testing.assert_allclose(r, e / 2)
-        
+
         r = average_filter(i, footprint=fp, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e / 2)
-        
+
         fp = numpy.array(
             [[1, 0],
              [1, 0],
@@ -159,9 +159,9 @@ class TestMetrics(unittest.TestCase):
             [[ 5, 7, 3],
              [10,13, 8],
              [ 8,10,12]])
-        r = average_filter(i, footprint=fp, mode='constant', cval=0, output=numpy.float)
+        r = average_filter(i, footprint=fp, mode='constant', cval=0, output=float)
         numpy.testing.assert_allclose(r, e / 3.)
-        
+
         i = numpy.array(
             [[1,3,4],
              [2,2,2]])
@@ -170,55 +170,55 @@ class TestMetrics(unittest.TestCase):
         e = numpy.array(
             [[6,5,6],
              [4,4,4]])
-        r = average_filter(i, footprint=fp, mode='mirror', output=numpy.float)
+        r = average_filter(i, footprint=fp, mode='mirror', output=float)
         numpy.testing.assert_allclose(r, e / 2.)
-        
+
         e = numpy.array(
             [[4,5,7],
              [4,4,4]])
-        r = average_filter(i, footprint=fp, mode='reflect', output=numpy.float)
+        r = average_filter(i, footprint=fp, mode='reflect', output=float)
         numpy.testing.assert_allclose(r, e / 2.)
-        
+
     def test_sum_filter(self):
         i = numpy.array(
             [[1,2,3],
              [3,4,5],
              [5,6,7]])
-        
+
         # test reaction to size parameter
         r = sum_filter(i, size=1)
         numpy.testing.assert_allclose(r, i)
-        
+
         e = numpy.array(
             [[10,14, 8],
              [18,22,12],
              [11,13, 7]])
         r = sum_filter(i, size=2, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         e = numpy.array(
             [[10,18,14],
              [21,36,27],
              [18,30,22]])
         r = sum_filter(i, size=3, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         e = numpy.array(
             [[36,36,36],
              [36,36,36],
              [36,36,36]])
         r = sum_filter(i, size=5, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         r = sum_filter(i, size=10, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         # test reaction to footprint parameter
         fp = numpy.array(
             [[1]])
         r = sum_filter(i, footprint=fp)
         numpy.testing.assert_allclose(r, i)
-        
+
         fp = numpy.array(
             [[1,1],
              [1,1]])
@@ -228,7 +228,7 @@ class TestMetrics(unittest.TestCase):
              [11,13, 7]])
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         fp = numpy.array(
             [[1, 1]])
         e = numpy.array(
@@ -237,7 +237,7 @@ class TestMetrics(unittest.TestCase):
              [11,13, 7]])
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         fp = numpy.array(
             [[1],
              [1]])
@@ -247,7 +247,7 @@ class TestMetrics(unittest.TestCase):
              [ 5, 6, 7]])
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         fp = numpy.array(
             [[1, 0],
              [1, 0],
@@ -258,7 +258,7 @@ class TestMetrics(unittest.TestCase):
              [ 8,10,12]])
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         fp = numpy.array(
             [[1, 0],
              [0, 1],
@@ -269,66 +269,66 @@ class TestMetrics(unittest.TestCase):
              [ 9,11, 5]])
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         numpy.testing.assert_allclose(r, e)
-        
+
         # test border treatment modes
         i = numpy.array(
             [[1,3,4],
              [2,2,2]])
         fp = numpy.array(
             [[1,0,1]])
-        
+
         e = 6
         r = sum_filter(i, footprint=fp, mode='mirror')
         self.assertAlmostEqual(r[0,0], e, msg='mirror mode failed')
-        
+
         e = 4
         r = sum_filter(i, footprint=fp, mode='reflect')
         self.assertAlmostEqual(r[0,0], e, msg='reflect mode failed')
-        
+
         e = 7
         r = sum_filter(i, footprint=fp, mode='wrap')
         self.assertAlmostEqual(r[0,0], e, msg='wrap mode failed')
-        
+
         e = 4
         r = sum_filter(i, footprint=fp, mode='nearest')
         self.assertAlmostEqual(r[0,0], e, msg='nearest mode failed')
-        
+
         e = 3
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         self.assertAlmostEqual(r[0,0], e, msg='constant mode failed')
-        
+
         e = 12
         r = sum_filter(i, footprint=fp, mode='constant', cval=9)
         self.assertAlmostEqual(r[0,0], e, msg='constant mode failed')
-        
+
         fp = numpy.array(
             [[1,0,0],
              [0,0,0]])
-        
+
         e = 3
         r = sum_filter(i, footprint=fp, mode='mirror')
         self.assertAlmostEqual(r[0,0], e, msg='mirror mode failed')
-        
+
         e = 1
         r = sum_filter(i, footprint=fp, mode='reflect')
         self.assertAlmostEqual(r[0,0], e, msg='reflect mode failed')
-        
+
         e = 4
         r = sum_filter(i, footprint=fp, mode='wrap')
         self.assertAlmostEqual(r[0,0], e, msg='wrap mode failed')
-        
+
         e = 1
         r = sum_filter(i, footprint=fp, mode='nearest')
         self.assertAlmostEqual(r[0,0], e, msg='nearest mode failed')
-        
+
         e = 0
         r = sum_filter(i, footprint=fp, mode='constant', cval=0)
         self.assertAlmostEqual(r[0,0], e, msg='constant mode failed')
-        
+
         e = 9
         r = sum_filter(i, footprint=fp, mode='constant', cval=9)
-        self.assertAlmostEqual(r[0,0], e, msg='constant mode failed')        
-        
+        self.assertAlmostEqual(r[0,0], e, msg='constant mode failed')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/graphcut_/energy_label.py
+++ b/tests/graphcut_/energy_label.py
@@ -24,12 +24,12 @@ from medpy.graphcut.graph import GCGraph
 
 # code
 class TestEnergyLabel(unittest.TestCase):
-    
+
     BOUNDARY_TERMS = [boundary_stawiaski, boundary_difference_of_means,
                       boundary_stawiaski_directed, regional_atlas]
     BOUNDARY_TERMS_1ARG = [boundary_stawiaski, boundary_difference_of_means]
     BOUNDARY_TERMS_2ARG = [boundary_stawiaski_directed, regional_atlas]
-    
+
     # dedicated function tests
     def test_boundary_stawiaski(self):
         label = [[[1,1],
@@ -37,54 +37,54 @@ class TestEnergyLabel(unittest.TestCase):
                  [[1,2],
                   [2,2]],
                  [[2,2],
-                  [2,2,]]] 
+                  [2,2,]]]
         expected_result = {(0, 1): (6, 6)}
         self.__run_boundary_stawiaski_test(label, numpy.zeros_like(label), expected_result, '3D images')
-        
+
         gradient = [[0., 0., 0.],
                     [0., 0., sys.float_info.max]]
         label = [[1, 2, 3],
                  [1, 2, 4]]
         expected_result = {(0, 1): (2.0, 2.0), (1, 2): (1.0, 1.0), (1, 3): (sys.float_info.min, sys.float_info.min), (2, 3): (sys.float_info.min, sys.float_info.min)}
         self.__run_boundary_stawiaski_test(label, gradient, expected_result, 'zero edge weight')
-        
+
         label = [[1, 3, 4],
                  [1, 2, 5],
                  [1, 2, 5]]
         expected_result = {(0, 1): (2.0, 2.0), (0, 2): (1.0, 1.0), (2, 3): (1.0, 1.0), (1, 2): (1.0, 1.0), (1, 4): (2.0, 2.0), (3, 4): (1.0, 1.0)}
-        self.__run_boundary_stawiaski_test(label, numpy.zeros(numpy.asarray(label).shape, numpy.int), expected_result, 'integer gradient image')
-        
+        self.__run_boundary_stawiaski_test(label, numpy.zeros(numpy.asarray(label).shape, int), expected_result, 'integer gradient image')
+
         label = scipy.asarray(label, order='C') # C-order, gradient same order
         gradient = scipy.zeros(label.shape, order='C')
         self.__run_boundary_stawiaski_test(label, gradient, expected_result, 'order (C, C)')
-        
+
         label = scipy.asarray(label, order='F') # Fortran order, gradient same order
         gradient = scipy.zeros(label.shape, order='F')
         self.__run_boundary_stawiaski_test(label, gradient, expected_result, 'order (F, F)')
-        
+
         label = scipy.asarray(label, order='C') # C-order, gradient different order
         gradient = scipy.zeros(label.shape, order='F')
         self.__run_boundary_stawiaski_test(label, gradient, expected_result, 'order (C, F)')
-        
+
         label = scipy.asarray(label, order='F') # F-order, gradient different order
         gradient = scipy.zeros(label.shape, order='C')
         self.__run_boundary_stawiaski_test(label, gradient, expected_result, 'order (F, C)')
-        
+
     def __run_boundary_stawiaski_test(self, label, gradient, expected_result, msg = ''):
         label = numpy.asarray(label)
         gradient = numpy.asarray(gradient)
         graph = GCGraphTest(numpy.unique(label).size, math.pow(numpy.unique(label).size, 2))
         boundary_stawiaski(graph, label, gradient)
         graph.validate_nweights(self, expected_result, msg)
-        
+
     def __run_boundary_difference_of_means_test(self, label, gradient, expected_result, msg = ''):
         label = numpy.asarray(label)
         gradient = numpy.asarray(gradient)
         graph = GCGraphTest(numpy.unique(label).size, math.pow(numpy.unique(label).size, 2))
         boundary_difference_of_means(graph, label, gradient)
         graph.validate_nweights(self, expected_result, msg)
-    
-    
+
+
     # exception tests
     def test_exception_not_consecutively_labelled(self):
         label = [[1, 4, 8],
@@ -94,7 +94,7 @@ class TestEnergyLabel(unittest.TestCase):
             assert_raises(AttributeError, bt, None, label, (None, ))
         for bt in self.BOUNDARY_TERMS_2ARG:
             assert_raises(AttributeError, bt, None, label, (None, None))
-            
+
     def test_exception_not_starting_with_index_one(self):
         label = [[2, 3, 4],
                  [2, 3, 4],
@@ -103,63 +103,63 @@ class TestEnergyLabel(unittest.TestCase):
             assert_raises(AttributeError, bt, None, label, (None, ))
         for bt in self.BOUNDARY_TERMS_2ARG:
             assert_raises(AttributeError, bt, None, label, (None, None))
-            
+
     def test_boundary_difference_of_means_borders(self):
         label = [[[1,1],
                   [1,1]],
                  [[1,2],
                   [2,2]],
                  [[2,2],
-                  [2,2,]]] 
+                  [2,2,]]]
         expected_result = {(0, 1): (sys.float_info.min, sys.float_info.min)}
         self.__run_boundary_difference_of_means_test(label, numpy.zeros_like(label), expected_result, '3D images')
-        
+
         gradient = [[0., 0., 0.],
                     [0., 0., sys.float_info.max]]
         label = [[1, 2, 3],
                  [1, 2, 4]]
         expected_result = {(0, 1): (1.0, 1.0), (1, 2): (1.0, 1.0), (1, 3): (sys.float_info.min, sys.float_info.min), (2, 3): (sys.float_info.min, sys.float_info.min)}
         self.__run_boundary_difference_of_means_test(label, gradient, expected_result, 'zero edge weight')
-        
+
         label = [[1, 3, 4],
                  [1, 2, 5],
                  [1, 2, 5]]
         expected_result = {(0, 1): (sys.float_info.min, sys.float_info.min), (0, 2): (sys.float_info.min, sys.float_info.min), (2, 3): (sys.float_info.min, sys.float_info.min), (1, 2): (sys.float_info.min, sys.float_info.min), (1, 4): (sys.float_info.min, sys.float_info.min), (3, 4): (sys.float_info.min, sys.float_info.min)}
-        self.__run_boundary_difference_of_means_test(label, numpy.zeros(numpy.asarray(label).shape, numpy.int), expected_result, 'integer gradient image')
-        
+        self.__run_boundary_difference_of_means_test(label, numpy.zeros(numpy.asarray(label).shape, int), expected_result, 'integer gradient image')
+
         label = scipy.asarray(label, order='C') # C-order, gradient same order
         gradient = scipy.zeros(label.shape, order='C')
         self.__run_boundary_difference_of_means_test(label, gradient, expected_result, 'order (C, C)')
-        
+
         label = scipy.asarray(label, order='F') # Fortran order, gradient same order
         gradient = scipy.zeros(label.shape, order='F')
         self.__run_boundary_difference_of_means_test(label, gradient, expected_result, 'order (F, F)')
-        
+
         label = scipy.asarray(label, order='C') # C-order, gradient different order
         gradient = scipy.zeros(label.shape, order='F')
         self.__run_boundary_difference_of_means_test(label, gradient, expected_result, 'order (C, F)')
-        
+
         label = scipy.asarray(label, order='F') # F-order, gradient different order
         gradient = scipy.zeros(label.shape, order='C')
         self.__run_boundary_difference_of_means_test(label, gradient, expected_result, 'order (F, C)')
-            
+
 class GCGraphTest(GCGraph):
     """Wrapper around GCGraph, disabling its main functionalities to enable checking of the received values."""
-    
+
     def __init__(self, nodes, edges):
         self.__nodes = nodes
         self.__edges = edges
         self.__nweights = dict()
-        
+
     def set_nweight(self, node_from, node_to, weight_there, weight_back):
         """Original graph sums if edges already exists."""
         #print (node_from, node_to, weight_there, weight_back)
         if not (node_from, node_to) in self.__nweights:
             self.__nweights[(node_from, node_to)] = (weight_there, weight_back)
         else:
-            weight_there_old, weight_back_old = self.__nweights[(node_from, node_to)] 
+            weight_there_old, weight_back_old = self.__nweights[(node_from, node_to)]
             self.__nweights[(node_from, node_to)] = (weight_there_old + weight_there, weight_back_old + weight_back)
-        
+
     def get_nweights(self):
         return self.__nweights
 
@@ -183,10 +183,10 @@ class GCGraphTest(GCGraph):
                 unittest.assertAlmostEqual(value[1], expected_result[key][1], msg='{}: Weight for region border {} is {}. Expected {}.'.format(msg_base, key, value, expected_result[key]), delta=sys.float_info.epsilon)
                 unittest.assertGreater(value[0], 0.0, '{}: Encountered a weight {} <= 0.0 for key {}.'.format(msg_base, value, key))
                 unittest.assertGreater(value[1], 0.0, '{}: Encountered a weight {} <= 0.0 for key {}.'.format(msg_base, value, key))
-                
+
         for key, value in list(expected_result.items()):
             unittest.assertTrue(key in result, '{}: Region border {} expectedly but not found in results.'.format(msg_base, key))
-            
-        
+
+
 if __name__ == '__main__':
-    unittest.main()    
+    unittest.main()

--- a/tests/graphcut_/energy_voxel.py
+++ b/tests/graphcut_/energy_voxel.py
@@ -23,7 +23,7 @@ from medpy.graphcut.energy_voxel import boundary_difference_linear, boundary_dif
                                         regional_probability_map
 
 class TestEnergyVoxel(unittest.TestCase):
-    
+
     BOUNDARY_TERMS = [boundary_difference_linear, boundary_difference_exponential,\
                       boundary_difference_division, boundary_difference_power,\
                       boundary_maximum_linear, boundary_maximum_exponential,\
@@ -33,11 +33,11 @@ class TestEnergyVoxel(unittest.TestCase):
                             boundary_difference_division, boundary_difference_power,\
                             boundary_maximum_exponential,\
                             boundary_maximum_division, boundary_maximum_power]
-    
+
     image  = numpy.asarray([[0,0,0,0],
                             [0,0,0,0],
                             [0,0,1,1],
-                            [0,0,1,1]], dtype=numpy.float)
+                            [0,0,1,1]], dtype=float)
     fgmarkers = numpy.asarray([[0,0,0,0],
                                [0,0,0,0],
                                [0,0,0,0],
@@ -49,76 +49,76 @@ class TestEnergyVoxel(unittest.TestCase):
     result = numpy.asarray([[0,0,0,0],
                             [0,0,0,0],
                             [0,0,1,1],
-                            [0,0,1,1]], dtype=numpy.bool)
-    
+                            [0,0,1,1]], dtype=numpy.bool_)
+
     gradient  = numpy.asarray([[0,0,0,0],
                                [0,1,1,1],
                                [0,1,0,0],
-                               [0,1,0,0]], dtype=numpy.float)
-    
+                               [0,1,0,0]], dtype=float)
+
     # Base functionality tests
     def test_boundary_difference_linear_2D(self):
         self.__test_boundary_term_2d(boundary_difference_linear, (self.image, False))
-        
+
     def test_boundary_difference_exponential_2D(self):
         self.__test_boundary_term_2d(boundary_difference_exponential, (self.image, 1., False))
-        
+
     def test_boundary_difference_division_2D(self):
         self.__test_boundary_term_2d(boundary_difference_division, (self.image, .5, False))
-        
+
     def test_boundary_difference_power_2D(self):
         self.__test_boundary_term_2d(boundary_difference_power, (self.image, 2., False))
-        
+
     def test_boundary_maximum_linear_2D(self):
         self.__test_boundary_term_2d(boundary_maximum_linear, (self.gradient, False))
-        
+
     def test_boundary_maximum_exponential_2D(self):
         self.__test_boundary_term_2d(boundary_maximum_exponential, (self.gradient, 1., False))
-        
+
     def test_boundary_maximum_division_2D(self):
         self.__test_boundary_term_2d(boundary_maximum_division, (self.gradient, .5, False))
-        
+
     def test_boundary_maximum_power_2D(self):
         self.__test_boundary_term_2d(boundary_maximum_power, (self.gradient, 2., False))
-        
+
     def test_regional_probability_map(self):
         probability = self.image / 2.
         self.__test_regional_term_2d(regional_probability_map, (probability, 1.0))
-        
+
     # Spacing tests
     def test_spacing(self):
         image = numpy.asarray([[0,0,0,0,0],
                                [0,0,2,0,0],
                                [0,0,2,0,0],
                                [0,0,2,0,0],
-                               [0,0,2,0,0]], dtype=numpy.float)
+                               [0,0,2,0,0]], dtype=float)
         fgmarkers = numpy.asarray([[0,0,0,0,0],
                                    [0,0,0,0,0],
                                    [0,0,0,0,0],
                                    [0,0,0,0,0],
-                                   [0,0,1,0,0]], dtype=numpy.bool)
+                                   [0,0,1,0,0]], dtype=numpy.bool_)
         bgmarkers = numpy.asarray([[1,0,0,0,1],
                                    [0,0,0,0,0],
                                    [0,0,0,0,0],
                                    [0,0,0,0,0],
-                                   [0,0,0,0,0]], dtype=numpy.bool)
-        expected = image.astype(numpy.bool)
+                                   [0,0,0,0,0]], dtype=numpy.bool_)
+        expected = image.astype(numpy.bool_)
         graph = graph_from_voxels(fgmarkers,
                                   bgmarkers,
                                   boundary_term=boundary_difference_division,
                                   boundary_term_args=(image, 1.0, (1., 5.0)))
         result = self.__execute(graph, image)
         assert_array_equal(result, expected)
-        
+
     # Special case tests
     def test_negative_image(self):
-        image = numpy.asarray([[-1,1,-4],[2,-7,3],[-2.3,3,-7]], dtype=numpy.float)
+        image = numpy.asarray([[-1,1,-4],[2,-7,3],[-2.3,3,-7]], dtype=float)
         self.__test_all_on_image(image)
-        
+
     def test_zero_image(self):
-        image = numpy.asarray([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float)
+        image = numpy.asarray([[0,0,0],[0,0,0],[0,0,0]], dtype=float)
         self.__test_all_on_image(image)
-    
+
     # Helper functions
     def __test_all_on_image(self, image):
         for bt in self.BOUNDARY_TERMS_2ARGS:
@@ -127,14 +127,14 @@ class TestEnergyVoxel(unittest.TestCase):
                                       boundary_term=bt,
                                       boundary_term_args=(image, False))
             self.__execute(graph, self.image)
-        
+
         for bt in self.BOUNDARY_TERMS_3ARGS:
             graph = graph_from_voxels(self.fgmarkers,
                                       self.bgmarkers,
                                       boundary_term=bt,
                                       boundary_term_args=(image, 1.0, False))
             self.__execute(graph, self.image)
-        
+
     def __test_boundary_term_2d(self, term, term_args):
         graph = graph_from_voxels(self.fgmarkers,
                                   self.bgmarkers,
@@ -142,7 +142,7 @@ class TestEnergyVoxel(unittest.TestCase):
                                   boundary_term_args=term_args)
         result = self.__execute(graph, self.image)
         assert_array_equal(result, self.result)
-        
+
     def __test_regional_term_2d(self, term, term_args):
         graph = graph_from_voxels(self.fgmarkers,
                                   self.bgmarkers,
@@ -150,7 +150,7 @@ class TestEnergyVoxel(unittest.TestCase):
                                   regional_term_args=term_args)
         result = self.__execute(graph, self.image)
         assert_array_equal(result, self.result)
-        
+
     def __execute(self, graph, image):
         """Executes a graph cut and returns the processed results."""
         # execute min-cut / executing BK_MFMC
@@ -158,13 +158,13 @@ class TestEnergyVoxel(unittest.TestCase):
             graph.maxflow()
         except Exception as e:
             self.fail('An error was thrown during the external executions: {}'.format(e.message))
-            
+
         # reshape results to form a valid mask
-        result = numpy.zeros(image.size, dtype=numpy.bool)
-        for idx in range(len(result)): 
+        result = numpy.zeros(image.size, dtype=numpy.bool_)
+        for idx in range(len(result)):
             result[idx] = 0 if graph.termtype.SINK == graph.what_segment(idx) else 1
         return result.reshape(image.shape)
-        
+
     def __print_nweights(self, graph):
         n = graph.get_node_num()
         for i in range(n):


### PR DESCRIPTION
Numpy 1.24 [deprecated](https://numpy.org/devdocs/release/1.24.0-notes.html)
 - np.bool
 - np.int
 - np.float

Attempting to run MedPy raised an AttributeError that these weren't installed (I found this for `metrics.hd95`) This replaces them with `np.bool_`, `int`, and `float`, respectively, so medpy can continue to work with the latest Numpy