### PR TITLE
WIP: Use Numpy modules directly instead of SciPy aliases

### DIFF
--- a/tests/features_/histogram.py
+++ b/tests/features_/histogram.py
@@ -14,7 +14,7 @@ import math
 import unittest
 
 # third-party modules
-import scipy
+import numpy as np
 
 # own modules
 from medpy.features.histogram import (
@@ -30,7 +30,7 @@ from medpy.features.histogram import (
 class TestHistogramFeatures(unittest.TestCase):
     def test_fuzzy_histogram_contribution(self):
         """Test if all values contribute with nearly one to the created histograms."""
-        values = scipy.random.randint(0, 100, 1000)
+        values = np.random.randint(0, 100, 1000)
 
         # test triangular
         h, _ = fuzzy_histogram(
@@ -236,7 +236,7 @@ class TestHistogramFeatures(unittest.TestCase):
 
     def test_fuzzy_histogram_std_behaviour(self):
         """Test the standard behaviour of fuzzy histogram."""
-        values = scipy.random.randint(0, 10, 100)
+        values = np.random.randint(0, 10, 100)
 
         _, b = fuzzy_histogram(values, bins=12)
         self.assertEqual(len(b), 13, "violation of requested histogram size.")
@@ -258,7 +258,7 @@ class TestHistogramFeatures(unittest.TestCase):
         self.assertEqual(b[-1], 5.0, "violation of requested ranges lower bound.")
 
     def test_fuzzy_histogram_parameters(self):
-        values = scipy.random.randint(0, 10, 100)
+        values = np.random.randint(0, 10, 100)
 
         # membership functions
         fuzzy_histogram(values, membership="triangular")
@@ -276,7 +276,7 @@ class TestHistogramFeatures(unittest.TestCase):
         )  # float in smoothness
 
     def test_fuzzy_histogram_exceptions(self):
-        values = scipy.random.randint(0, 10, 100)
+        values = np.random.randint(0, 10, 100)
 
         # test fuzzy histogram exceptions
         self.assertRaises(AttributeError, fuzzy_histogram, values, range=(0, 0))

--- a/tests/filter_/houghtransform.py
+++ b/tests/filter_/houghtransform.py
@@ -11,6 +11,7 @@ Unittest for medpy.filter.houghtransform
 import unittest
 
 # third-party modules
+import numpy as np
 import scipy
 
 # own modules
@@ -235,35 +236,35 @@ class TestHoughTransform(unittest.TestCase):
     def test_dimensions(self):
         # 1D
         img = scipy.rand(10)
-        template = scipy.random.randint(0, 2, (3))
+        template = np.random.randint(0, 2, (3))
         result = ght(img, template)
         self.assertEqual(
             result.ndim, 1, "Computing ght with one-dimensional input data failed."
         )
         # 2D
         img = scipy.rand(10, 11)
-        template = scipy.random.randint(0, 2, (3, 4))
+        template = np.random.randint(0, 2, (3, 4))
         result = ght(img, template)
         self.assertEqual(
             result.ndim, 2, "Computing ght with two-dimensional input data failed."
         )
         # 3D
         img = scipy.rand(10, 11, 12)
-        template = scipy.random.randint(0, 2, (3, 4, 5))
+        template = np.random.randint(0, 2, (3, 4, 5))
         result = ght(img, template)
         self.assertEqual(
             result.ndim, 3, "Computing ght with three-dimensional input data failed."
         )
         # 4D
         img = scipy.rand(10, 11, 12, 13)
-        template = scipy.random.randint(0, 2, (3, 4, 5, 6))
+        template = np.random.randint(0, 2, (3, 4, 5, 6))
         result = ght(img, template)
         self.assertEqual(
             result.ndim, 4, "Computing ght with four-dimensional input data failed."
         )
         # 5D
         img = scipy.rand(3, 4, 3, 4, 3)
-        template = scipy.random.randint(0, 2, (2, 2, 2, 2, 2))
+        template = np.random.randint(0, 2, (2, 2, 2, 2, 2))
         result = ght(img, template)
         self.assertEqual(
             result.ndim, 5, "Computing ght with five-dimensional input data failed."

--- a/tests/io_/loadsave.py
+++ b/tests/io_/loadsave.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 
 # third-party modules
+import numpy as np
 import scipy
 
 from medpy.core.logger import Logger
@@ -196,7 +197,7 @@ class TestIOFacilities(unittest.TestCase):
         try:
             for ndim in __ndims:
                 logger.debug("Testing for dimension {}...".format(ndim))
-                arr_base = scipy.random.randint(0, 10, list(range(10, ndim + 10)))
+                arr_base = np.random.randint(0, 10, list(range(10, ndim + 10)))
                 for dtype in __dtypes:
                     arr_save = arr_base.astype(dtype)
                     for suffix in __suffixes:

--- a/tests/io_/metadata.py
+++ b/tests/io_/metadata.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 
 # third-party modules
+import numpy as np
 import scipy
 
 from medpy.core.logger import Logger
@@ -212,7 +213,7 @@ class TestMetadataConsistency(unittest.TestCase):
         try:
             for ndim in __ndims:
                 logger.debug("Testing for dimension {}...".format(ndim))
-                arr_base = scipy.random.randint(0, 10, list(range(10, ndim + 10)))
+                arr_base = np.random.randint(0, 10, list(range(10, ndim + 10)))
                 for dtype in __dtypes:
                     arr_save = arr_base.astype(dtype)
                     for suffix_from in __suffixes:
@@ -258,7 +259,7 @@ class TestMetadataConsistency(unittest.TestCase):
                         header.set_pixel_spacing(
                             hdr_from,
                             [
-                                scipy.random.rand() * scipy.random.randint(1, 10)
+                                np.random.rand() * np.random.randint(1, 10)
                                 for _ in range(img_from.ndim)
                             ],
                         )
@@ -266,14 +267,14 @@ class TestMetadataConsistency(unittest.TestCase):
                             header.set_pixel_spacing(
                                 hdr_from,
                                 [
-                                    scipy.random.rand() * scipy.random.randint(1, 10)
+                                    np.random.rand() * np.random.randint(1, 10)
                                     for _ in range(img_from.ndim)
                                 ],
                             )
                             header.set_offset(
                                 hdr_from,
                                 [
-                                    scipy.random.rand() * scipy.random.randint(1, 10)
+                                    np.random.rand() * np.random.randint(1, 10)
                                     for _ in range(img_from.ndim)
                                 ],
                             )


### PR DESCRIPTION
Commit 1: switch scipy.random to np.random
See https://github.com/scipy/scipy/issues/14889 for reference

In current SciPy versions, scipy.random is no longer a thing (was previously an alias for np.random)